### PR TITLE
switch to `search_engine=v3`

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -101,7 +101,7 @@ export default (storage, scriptManager) => {
           page: req.query.page || 0,
           include_totals: true,
           fields: 'user_id,username,name,email,identities,picture,last_login,logins_count,multifactor,blocked,app_metadata,user_metadata',
-          search_engine: 'v2'
+          search_engine: 'v3'
         };
 
         return req.auth0.users.getAll(options);


### PR DESCRIPTION
we are about to allow only `v3` for new tenants, so we should start using it in all extensions.
currently, this is the only extension using the search users endpoint.