### PR TITLE
no admin's access tokens on frontend

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
   "dependencies": {
     "async": "^1.5.2",
     "auth0": "^2.8.0",
-    "auth0-extension-express-tools": "git+https://github.com/zxan1285/auth0-extension-express-tools.git#no-access-token",
-    "auth0-extension-tools": "git+https://github.com/zxan1285/auth0-extension-tools.git#no-access-token",
+    "auth0-extension-express-tools": "1.1.8",
+    "auth0-extension-tools": "1.3.3",
     "auth0-extension-ui": "~1.1.6",
     "auth0-js": "^9.6.0",
     "axios": "^0.14.0",

--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   "auth0-extension": {
     "externals": [
       "async@2.1.2",
-      "auth0-extension-tools@1.3.1",
-      "auth0@2.4.0",
+      "auth0@2.8.0",
       "aws-sdk@2.5.3",
       "blipp@2.3.0",
       "bluebird@3.4.6",
@@ -64,9 +63,9 @@
   "license": "MIT",
   "dependencies": {
     "async": "^1.5.2",
-    "auth0": "^2.1.0",
-    "auth0-extension-express-tools": "1.1.7",
-    "auth0-extension-tools": "1.3.1",
+    "auth0": "^2.8.0",
+    "auth0-extension-express-tools": "git+https://github.com/zxan1285/auth0-extension-express-tools.git#no-access-token",
+    "auth0-extension-tools": "git+https://github.com/zxan1285/auth0-extension-tools.git#no-access-token",
     "auth0-extension-ui": "~1.1.6",
     "auth0-js": "^9.6.0",
     "axios": "^0.14.0",
@@ -123,7 +122,7 @@
     "winston": "^2.2.0"
   },
   "devDependencies": {
-    "auth0-extensions-cli": "^1.0.8",
+    "auth0-extensions-cli": "~1.0.9",
     "autoprefixer": "^6.5.1",
     "babel-eslint": "7.2.3",
     "babel-loader": "7.0.0",

--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,7 @@ module.exports = (cfg, storageProvider) => {
     baseUrl: config('PUBLIC_WT_URL'),
     webtaskUrl: config('PUBLIC_WT_URL'),
     clientName: 'Delegated Administration',
+    noAccessToken : true,
     urlPrefix: '/admins',
     sessionStorageKey: 'delegated-admin:apiToken',
     scopes: 'read:clients delete:clients read:connections read:users update:users delete:users create:users read:logs read:device_credentials update:device_credentials delete:device_credentials delete:guardian_enrollments'


### PR DESCRIPTION
✏️ Changes
Added option to exclude admin's accessToken from idToken as a temporary solution of DAE 3.0 security.
We need to publish these:
https://github.com/auth0-extensions/auth0-extension-tools/pull/14
https://github.com/auth0-extensions/auth0-extension-express-tools/pull/15
before merging.

🔗 References
Jira: https://auth0team.atlassian.net/browse/KEY-159

🎯 Testing
✅ This has been tested locally
✅ This has been tested in a webtask