### PR TITLE
Namespaced roles

### DIFF
--- a/server/lib/getScopes.js
+++ b/server/lib/getScopes.js
@@ -4,27 +4,18 @@ import * as constants from '../constants';
 
 
 const getUserAccess = (user, type) => {
-  let namespace = null;
-
-  _.forEach(user, (val, key) => {
-    if (key.indexOf('https:') === 0 && key.indexOf('auth0-delegated-admin') > 0) {
-      namespace = key;
-    }
-  });
+  const claim = _.find(user, (val, key) => _.startsWith(key, 'https:') && _.endsWith(key, 'auth0-delegated-admin'));
 
   const items = [
     user[type],
     user.app_metadata && user.app_metadata[type],
-    user.app_metadata && user.app_metadata.authorization && user.app_metadata.authorization[type]
+    user.app_metadata && user.app_metadata.authorization && user.app_metadata.authorization[type],
+    claim && claim[type]
   ];
-
-  if (namespace) {
-    items.push(user[namespace][type]);
-  }
 
   return _(items)
     .flatten()
-    .filter(item => item)
+    .compact()
     .uniq()
     .value();
 };
@@ -43,8 +34,6 @@ const checkRole = (data) => {
 };
 
 export default function(user) {
-  console.log(user);
-
   const roles = getUserAccess(user, 'roles');
   const permissions = getUserAccess(user, 'permissions');
   const userRole = checkRole(roles);

--- a/server/lib/getScopes.js
+++ b/server/lib/getScopes.js
@@ -4,11 +4,24 @@ import * as constants from '../constants';
 
 
 const getUserAccess = (user, type) => {
+  let namespace = null;
+
+  _.forEach(user, (val, key) => {
+    if (key.indexOf('https:') === 0 && key.indexOf('auth0-delegated-admin') > 0) {
+      namespace = key;
+    }
+  });
+
   const items = [
     user[type],
     user.app_metadata && user.app_metadata[type],
     user.app_metadata && user.app_metadata.authorization && user.app_metadata.authorization[type]
   ];
+
+  if (namespace) {
+    items.push(user[namespace][type]);
+  }
+
   return _(items)
     .flatten()
     .filter(item => item)
@@ -30,6 +43,8 @@ const checkRole = (data) => {
 };
 
 export default function(user) {
+  console.log(user);
+
   const roles = getUserAccess(user, 'roles');
   const permissions = getUserAccess(user, 'permissions');
   const userRole = checkRole(roles);

--- a/tests/server/lib/getScopes.tests.js
+++ b/tests/server/lib/getScopes.tests.js
@@ -1,0 +1,52 @@
+import { expect } from 'chai';
+
+import getScopes from '../../../server/lib/getScopes';
+import * as constants from '../../../server/constants';
+
+const admins = {
+  meta: {
+    app_metadata: {
+      roles: constants.ADMIN_ROLE_NAME
+    }
+  },
+  role: {
+    roles: constants.ADMIN_ROLE_NAME
+  },
+  auth: {
+    app_metadata: {
+      authorization: {
+        roles: constants.ADMIN_ROLE_NAME
+      }
+    }
+  },
+  claim: {
+    'https://example.com/auth0-delegated-admin': {
+      roles: constants.ADMIN_ROLE_NAME
+    }
+  }
+};
+
+const adminScopes = [ constants.AUDITOR_PERMISSION, constants.USER_PERMISSION, constants.ADMIN_PERMISSION ];
+
+
+describe('getScopes', () => {
+  it('should get scopes from app_metadata', () => {
+    expect(getScopes(admins.meta)).to.eql(adminScopes);
+  });
+
+  it('should get scopes from user.roles', () => {
+    expect(getScopes(admins.role)).to.eql(adminScopes);
+  });
+
+  it('should get scopes from app_metadata.authorization', () => {
+    expect(getScopes(admins.auth)).to.eql(adminScopes);
+  });
+
+  it('should get scopes from namespaces claims', () => {
+    expect(getScopes(admins.claim)).to.eql(adminScopes);
+  });
+
+  it('should get no scopes', () => {
+    expect(getScopes({})).to.eql([]);
+  });
+});


### PR DESCRIPTION
✏️ Changes
With "Enable Legacy Profile" flag disabled, customer cannot set `user.roles` in the rule.
We're adding another option, which allows us to add roles to the namespaced claims of `idToken`.
Here's PR for docs: https://github.com/auth0/docs/pull/6521

🔗 References
Jira: https://auth0team.atlassian.net/browse/KEY-139

🎯 Testing
✅ This has been tested locally
✅ This has been tested in a webtask
✅ This change has unit tests