### PR TITLE
Search engine v2 deprication

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "Delegated Administration Dashboard",
   "engines": {
     "node": "8.9"

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -190,8 +190,6 @@ export default (storage, scriptManager) => {
 
     scriptManager.execute('filter', filterContext)
       .then((filter) => {
-        const searchEngine = filter && filter.searchEngine;
-        const defaultEngine = (config('AUTH0_RTA').replace('https://', '') !== 'auth0.auth0.com') ? 'v2' : 'v3';
         const filterQuery = (filter && typeof filter.query !== 'undefined') ? filter.query : filter;
         const options = {
           sort,
@@ -200,7 +198,7 @@ export default (storage, scriptManager) => {
           page: req.query.page || 0,
           include_totals: true,
           fields: 'user_id,username,name,email,identities,picture,last_login,logins_count,multifactor,blocked,app_metadata,user_metadata',
-          search_engine: searchEngine || (config('SEARCH_ENGINE') !== 'default' && config('SEARCH_ENGINE')) || defaultEngine
+          search_engine: (config('AUTH0_RTA').replace('https://', '') !== 'auth0.auth0.com') ? 'v2' : 'v3'
         };
 
         return req.auth0.users.getAll(options);

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Delegated Administration Dashboard",
   "name": "auth0-delegated-admin",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",
@@ -47,26 +47,6 @@
         {
           "value": "true",
           "text": "Yes"
-        }
-      ]
-    },
-    "SEARCH_ENGINE": {
-      "description": "Engine for searching users",
-      "type": "select",
-      "allowMultiple": false,
-      "default": "default",
-      "options": [
-        {
-          "value": "default",
-          "text": "Default"
-        },
-        {
-          "value": "v2",
-          "text": "v2"
-        },
-        {
-          "value": "v3",
-          "text": "v3"
         }
       ]
     }


### PR DESCRIPTION
## ✏️ Changes
  
Removed `SEARCH_ENGINE` option. Force v2 for appliances and v3 for cloud.
  
## 🔗 References
  
Slack Channel: https://auth0.slack.com/archives/CAYKL0SLU/p1535568799000100
Deprecation Case: https://auth0team.atlassian.net/wiki/spaces/DEP/pages/124682419/Deprecation+Case+User+Search+v2+ElasticSearch
Jira: https://auth0team.atlassian.net/browse/KEY-262
  
## 🎯 Testing
 
✅ This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
✅ This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will test manually via smoke test.
  
## 🔥 Rollback
  
We will rollback if we find an error during the smoke test.
  
### 📄 Procedure
  
Deploy a new patch-level update with reverted changes
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.