### PR TITLE
Hide actions for disabled fields

### DIFF
--- a/client/components/Users/UserActions.jsx
+++ b/client/components/Users/UserActions.jsx
@@ -95,6 +95,10 @@ export default class UserActions extends Component {
       return null;
     }
 
+    /* Check if settings are disabling the editing of password */
+    const falsePasswordEditFields = _.filter(this.props.userFields, field => field.property === 'password' && field.edit === false);
+    if (falsePasswordEditFields.length > 0) return null;
+
     return (
       <MenuItem disabled={loading || false} onClick={this.resetPassword}>
         {this.state.languageDictionary.resetPasswordMenuItemText || 'Reset Password'}
@@ -106,6 +110,10 @@ export default class UserActions extends Component {
     if (!this.state.databaseConnections || !this.state.databaseConnections.length) {
       return null;
     }
+
+    /* Check if settings are disabling the editing of password */
+    const falsePasswordEditFields = _.filter(this.props.userFields, field => field.property === 'password' && field.edit === false);
+    if (falsePasswordEditFields.length > 0) return null;
 
     return (
       <MenuItem disabled={loading || false} onClick={this.changePassword}>

--- a/tests/client/components/Users/UserActions.tests.js
+++ b/tests/client/components/Users/UserActions.tests.js
@@ -19,7 +19,7 @@ describe('#Client-Components-UserActions', () => {
   const unblockUser = () => 'unblockUser';
   const removeBlockedIPs = () => 'removeBlockedIPs';
 
-  const renderComponent = (user, languageDictionary) => {
+  const renderComponent = (user, languageDictionary, userFields = [{ edit: true }]) => {
     return shallow(
       <UserActions
         blockUser={blockUser}
@@ -35,11 +35,7 @@ describe('#Client-Components-UserActions', () => {
         unblockUser={unblockUser}
         removeBlockedIPs={removeBlockedIPs}
         user={fromJS(user)}
-        userFields={[
-          {
-            edit: true
-          }
-        ]}
+        userFields={userFields}
         languageDictionary={languageDictionary}
       />
     );
@@ -121,6 +117,24 @@ describe('#Client-Components-UserActions', () => {
       "Resend Verification Email": resendVerificationEmail(),
       "Reset Password": resetPassword(),
       "Change Username": changeUsername()
+    };
+
+    expect(Component.length).to.be.greaterThan(0);
+    const menuItems = Component.find('MenuItem');
+    checkMenuItems(menuItems, targets);
+  });
+
+  it('should not render change password, email and username, if those fields are disabled in userFields', () => {
+    const userFields = [
+      { property: 'password', edit: false },
+      { property: 'email', edit: false },
+      { property: 'username', edit: false }
+    ];
+    const Component = renderComponent({ username: 'bill' }, {}, userFields);
+    const targets = {
+      "Block User": blockUser(),
+      "Delete User": deleteUser(),
+      "Resend Verification Email": resendVerificationEmail()
     };
 
     expect(Component.length).to.be.greaterThan(0);


### PR DESCRIPTION
## ✏️ Changes
"Change Password" and "Reset Password" actions were visible even with `password` field disabled.
Now those actions will be hidden if `password` is disabled in the settings hook. 

## 🔗 References
Github issue: #115 
Jira: https://auth0team.atlassian.net/browse/KEY-240

## 🎯 Testing
✅ This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance