### PR TITLE
Custom favicon option

### DIFF
--- a/server/routes/html.js
+++ b/server/routes/html.js
@@ -15,7 +15,7 @@ export default () => {
       <meta charset="UTF-8" />
       <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
       <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-      <link rel="shortcut icon" href="https://cdn.auth0.com/styleguide/4.6.13/lib/logos/img/favicon.png">
+      <link rel="shortcut icon" href="<%= assets.favIcon %>" />
       <meta name="viewport" content="width=device-width, initial-scale=1">
       <link rel="stylesheet" type="text/css" href="https://cdn.auth0.com/styles/zocial.min.css" />
       <link rel="stylesheet" type="text/css" href="https://cdn.auth0.com/manage/v0.3.1672/css/index.min.css" />

--- a/server/routes/html.js
+++ b/server/routes/html.js
@@ -89,12 +89,14 @@ export default () => {
     const clientVersion = process.env.CLIENT_VERSION;
     if (clientVersion) {
       const cdnPath = config('CDN_PATH') || '//cdn.auth0.com/extensions/auth0-delegated-admin/assets';
+      const favIcon = config('FAVICON_PATH') || 'https://cdn.auth0.com/styleguide/4.6.13/lib/logos/img/favicon.png';
       return res.send(ejs.render(template, {
         config: settings,
         assets: {
           customCss: config('CUSTOM_CSS'),
           version: clientVersion,
-          cdnPath: cdnPath
+          cdnPath: cdnPath,
+          favIcon: favIcon
         }
       }));
     }

--- a/tests/server/routes/html.tests.js
+++ b/tests/server/routes/html.tests.js
@@ -1,0 +1,130 @@
+import { expect } from 'chai';
+
+import html from '../../../server/routes/html';
+import config from '../../../server/lib/config';
+
+const req = {
+  headers: {
+    host: 'localhost'
+  },
+  cookies: {},
+  url: '/login',
+  originalUrl: '/login'
+};
+
+describe.only('# /html', () => {
+  process.env.CLIENT_VERSION = '1.0';
+
+  it('should return html with default values', (done) => {
+    const route = html();
+    process.env.CLIENT_VERSION = '1.0';
+
+    const res = {
+      send: (body) => {
+        expect(body).to.be.a('string');
+        expect(body).to.include('<title></title>');
+        expect(body).to.include('<link rel="shortcut icon" href="https://cdn.auth0.com/styleguide/4.6.13/lib/logos/img/favicon.png" />');
+        expect(body).to.include('<script type="text/javascript" src="//cdn.auth0.com/extensions/auth0-delegated-admin/assets/auth0-delegated-admin.ui.1.0.js"></script>');
+
+        return done();
+      },
+      cookie: () => null
+    };
+
+    route(req, res);
+  });
+
+  it('should return html with FAVICON_PATH, CDN_PATH, TITLE and CUSTOM_CSS', (done) => {
+    const route = html();
+
+    config.setValue('FAVICON_PATH', 'https://example.com/favicon.png');
+    config.setValue('CDN_PATH', '//cdn.example.com');
+    config.setValue('TITLE', 'Testing');
+    config.setValue('CUSTOM_CSS', '//cdn.example.com/style.css');
+
+    const res = {
+      send: (body) => {
+        expect(body).to.be.a('string');
+        expect(body).to.include('<title>Testing</title>');
+        expect(body).to.include('<link rel="shortcut icon" href="https://example.com/favicon.png" />');
+        expect(body).to.include('<script type="text/javascript" src="//cdn.example.com/auth0-delegated-admin.ui.1.0.js"></script>');
+        expect(body).to.include('<link rel="stylesheet" type="text/css" href="//cdn.example.com/style.css" />');
+
+        return done();
+      },
+      cookie: () => null
+    };
+
+    route(req, res);
+  });
+
+  it('should set default (en) locale and redirect to /en/users', (done) => {
+    const route = html();
+
+    req.path = '/users';
+    req.url = '/users';
+    req.originalUrl = '/users';
+
+    const res = {
+      redirect: (path) => {
+        expect(path).to.equal('/en/users');
+
+        return done();
+      },
+      cookie: (key, value) => {
+        expect(key).to.equal('dae-locale');
+        expect(value).to.equal('en');
+      }
+    };
+
+    route(req, res);
+  });
+
+  it('should get cookie locale and redirect to /zz/users', (done) => {
+    const route = html();
+
+    req.path = '/users';
+    req.url = '/users';
+    req.originalUrl = '/users';
+    req.cookies = { 'dae-locale': 'zz' };
+
+    const res = {
+      redirect: (path) => {
+        expect(path).to.equal('/zz/users');
+
+        return done();
+      },
+      cookie: (key, value) => {
+        expect(key).to.equal('dae-locale');
+        expect(value).to.equal('zz');
+      }
+    };
+
+    route(req, res);
+  });
+
+
+  it('should get url locale and set it to cookie', (done) => {
+    const route = html();
+
+    req.path = '/xx/users';
+    req.url = '/xx/users';
+    req.originalUrl = '/xx/users';
+    req.cookies = { };
+
+    const res = {
+      send: (body) => {
+        expect(body).to.be.a('string');
+        expect(body).to.include('"LOCALE":"xx"');
+
+        return done();
+      },
+      cookie: (key, value) => {
+        expect(key).to.equal('dae-locale');
+        expect(value).to.equal('xx');
+      }
+    };
+
+    route(req, res);
+  });
+});

--- a/webtask.json
+++ b/webtask.json
@@ -35,6 +35,11 @@
       "example": "https://cdn.fabrikam.com/static/extensions/theme/fabrikam.css",
       "required": false
     },
+    "FAVICON_PATH": {
+      "description": "Path to custom favicon",
+      "example": "https://cdn.fabrikam.com/static/extensions/theme/favicon.png",
+      "required": false
+    },
     "FEDERATED_LOGOUT": {
       "description": "Also sign out from the IDP when users logout?",
       "type": "select",


### PR DESCRIPTION
## ✏️ Changes
  This PR contains all the changes from #120. The only difference is that now `FAVICON_PATH` secret is exposed in `webtask.json`, so customer can manage it from the extension gallery.

## 🔗 References
  Jira: https://auth0team.atlassian.net/browse/KEY-277
  
## 🎯 Testing
✅ This change has been tested locally