### PR TITLE
Custom fields search bug fix

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -180,10 +180,14 @@ export default (storage, scriptManager) => {
       }
     };
 
+    const searchEngine = (config('AUTH0_RTA').replace('https://', '') !== 'auth0.auth0.com') ? 'v2' : 'v3';
+    const quoteChar = searchEngine === 'v2' ? '"' : '';
     let searchQuery = req.query.search;
+
     if (req.query.filterBy && req.query.filterBy.length > 0) {
-      searchQuery = `${req.query.filterBy}:"${req.query.search}"`;
+      searchQuery = `${req.query.filterBy}:${quoteChar}${req.query.search}${quoteChar}`;
     }
+
     const sort = req.query.sortProperty && req.query.sortOrder
       ? `${req.query.sortProperty}:${req.query.sortOrder}`
       : 'last_login:-1';
@@ -198,7 +202,7 @@ export default (storage, scriptManager) => {
           page: req.query.page || 0,
           include_totals: true,
           fields: 'user_id,username,name,email,identities,picture,last_login,logins_count,multifactor,blocked,app_metadata,user_metadata',
-          search_engine: (config('AUTH0_RTA').replace('https://', '') !== 'auth0.auth0.com') ? 'v2' : 'v3'
+          search_engine: searchEngine
         };
 
         return req.auth0.users.getAll(options);

--- a/tests/server/routes/users.tests.js
+++ b/tests/server/routes/users.tests.js
@@ -19,7 +19,7 @@ describe('#users router', () => {
     req.auth0 = {
       users: {
         getAll: (options) => {
-          if (options.q && options.q.startsWith('(user_id:"1")')) {
+          if (options.q && options.q.startsWith('(user_id:1)')) {
             return Promise.resolve({
               users: _.filter(defaultUsers, user => user.user_id === 1)
             });


### PR DESCRIPTION
## ✏️ Changes
  There was a bug in custom fields search. Search engine v3 does not work with quotes and wildcard character, but v2 - does. These changes meant to fix that bug by using quotes for search engine v2 (`email:"*@gmail.com`), and remove them for search engine v3 (`email:*@gmail.com`).
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1537813879000100
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time