### PR TITLE
Mostekcm ability to hide delete and reset password

### DIFF
--- a/client/components/Users/UserActions.jsx
+++ b/client/components/Users/UserActions.jsx
@@ -68,11 +68,16 @@ export default class UserActions extends Component {
     }
   }
 
-  getDeleteAction = (user, loading) => (
-    <MenuItem disabled={loading || false} onClick={this.deleteUser}>
-      {this.state.languageDictionary.deleteUserMenuItemText || 'Delete User'}
-    </MenuItem>
-  )
+  getDeleteAction = (user, loading) => {
+    const deleteField = _.filter(this.props.userFields, field => field.property === 'delete' && field.edit === false);
+    if (deleteField.length > 0) return null;
+
+    return (
+      <MenuItem disabled={loading || false} onClick={this.deleteUser}>
+        {this.state.languageDictionary.deleteUserMenuItemText || 'Delete User'}
+      </MenuItem>
+    );
+  }
 
   getChangeFieldsAction = (user, loading) => {
     if (!this.props.userFields || !this.props.userFields.length) {
@@ -96,7 +101,7 @@ export default class UserActions extends Component {
     }
 
     /* Check if settings are disabling the editing of password */
-    const falsePasswordEditFields = _.filter(this.props.userFields, field => field.property === 'password' && field.edit === false);
+    const falsePasswordEditFields = _.filter(this.props.userFields, field => field.property === 'reset_password' && field.edit === false);
     if (falsePasswordEditFields.length > 0) return null;
 
     return (

--- a/client/components/Users/UserActions.jsx
+++ b/client/components/Users/UserActions.jsx
@@ -101,7 +101,7 @@ export default class UserActions extends Component {
     }
 
     /* Check if settings are disabling the editing of password */
-    const falsePasswordEditFields = _.filter(this.props.userFields, field => field.property === 'reset_password' && field.edit === false);
+    const falsePasswordEditFields = _.filter(this.props.userFields, field => field.property === 'resetPassword' && field.edit === false);
     if (falsePasswordEditFields.length > 0) return null;
 
     return (

--- a/tests/client/components/Logs/LogsTable.tests.js
+++ b/tests/client/components/Logs/LogsTable.tests.js
@@ -74,7 +74,7 @@ describe('#Client-Components-Logs-LogsTable', () => {
     expect(header.length).to.equal(1);
     const columns = header.find(TableColumn);
     expect(columns.length).to.equal(6);
-    expect(columns.at(0).childAt(0).text()).to.equal('');
+    expect(columns.at(0).children().length).to.equal(0);
     expect(columns.at(1).childAt(0).text()).to.equal('Event');
     expect(columns.at(2).childAt(0).text()).to.equal('Description');
     expect(columns.at(3).childAt(0).text()).to.equal('Date');
@@ -126,7 +126,7 @@ describe('#Client-Components-Logs-LogsTable', () => {
     expect(header.length).to.equal(1);
     const columns = header.find(TableColumn);
     expect(columns.length).to.equal(6);
-    expect(columns.at(0).childAt(0).text()).to.equal('');
+    expect(columns.at(0).children().length).to.equal(0);
     expect(columns.at(1).childAt(0).text()).to.equal('Event');
     expect(columns.at(2).childAt(0).text()).to.equal('Description');
     expect(columns.at(3).childAt(0).text()).to.equal('Date');
@@ -180,7 +180,7 @@ describe('#Client-Components-Logs-LogsTable', () => {
     expect(header.length).to.equal(1);
     const columns = header.find(TableColumn);
     expect(columns.length).to.equal(6);
-    expect(columns.at(0).childAt(0).text()).to.equal('');
+    expect(columns.at(0).children().length).to.equal(0);
     expect(columns.at(1).childAt(0).text()).to.equal('EventHeader');
     expect(columns.at(2).childAt(0).text()).to.equal('DescriptionHeader');
     expect(columns.at(3).childAt(0).text()).to.equal('DateHeader');

--- a/tests/client/components/Users/UserActions.tests.js
+++ b/tests/client/components/Users/UserActions.tests.js
@@ -128,11 +128,31 @@ describe('#Client-Components-UserActions', () => {
     const userFields = [
       { property: 'password', edit: false },
       { property: 'email', edit: false },
-      { property: 'username', edit: false }
+      { property: 'username', edit: false },
+      { property: 'delete', edit: false }
     ];
     const Component = renderComponent({ username: 'bill' }, {}, userFields);
     const targets = {
       "Block User": blockUser(),
+      "Reset Password": resetPassword(),
+      "Resend Verification Email": resendVerificationEmail()
+    };
+
+    expect(Component.length).to.be.greaterThan(0);
+    const menuItems = Component.find('MenuItem');
+    checkMenuItems(menuItems, targets);
+  });
+
+  it('should not render reset password, if disabled in userFields', () => {
+    const userFields = [
+      { property: 'resetPassword', edit: false }
+    ];
+    const Component = renderComponent({ username: 'bill' }, {}, userFields);
+    const targets = {
+      "Block User": blockUser(),
+      "Change Email": changeEmail(),
+      "Change Username": changeUsername(),
+      "Change Password": changePassword(),
       "Delete User": deleteUser(),
       "Resend Verification Email": resendVerificationEmail()
     };

--- a/tests/client/components/Users/UserDevices.tests.js
+++ b/tests/client/components/Users/UserDevices.tests.js
@@ -38,9 +38,9 @@ describe('#Client-Components-UserDevices', () => {
     expect(header.length).to.equal(1);
     const columns = header.find(TableColumn);
     expect(columns.length).to.equal(3);
-    expect(columns.filterWhere(element =>
+    expect(columns.filterWhere(element => element.children().length === 1 &&
       element.childAt(0).text() === 'Device').length).to.equal(1);
-    expect(columns.filterWhere(element =>
+    expect(columns.filterWhere(element => element.children().length === 1 &&
       element.childAt(0).text() === '# of Tokens/Public Keys').length).to.equal(1);
 
     /* Test the rows */
@@ -88,9 +88,9 @@ describe('#Client-Components-UserDevices', () => {
     expect(header.length).to.equal(1);
     const columns = header.find(TableColumn);
     expect(columns.length).to.equal(3);
-    expect(columns.filterWhere(element =>
+    expect(columns.filterWhere(element => element.children().length === 1 &&
       element.childAt(0).text() === 'Device').length).to.equal(1);
-    expect(columns.filterWhere(element =>
+    expect(columns.filterWhere(element => element.children().length === 1 &&
       element.childAt(0).text() === '# of Tokens/Public Keys').length).to.equal(1);
 
     /* Test the rows */
@@ -143,9 +143,9 @@ describe('#Client-Components-UserDevices', () => {
     expect(header.length).to.equal(1);
     const columns = header.find(TableColumn);
     expect(columns.length).to.equal(3);
-    expect(columns.filterWhere(element =>
+    expect(columns.filterWhere(element => element.children().length === 1 &&
       element.childAt(0).text() === 'DeviceColumnHeader').length).to.equal(1);
-    expect(columns.filterWhere(element =>
+    expect(columns.filterWhere(element => element.children().length === 1 &&
       element.childAt(0).text() === 'DeviceNumberTokensColumnHeader').length).to.equal(1);
   });
 

--- a/tests/server/lib/scriptmanager.tests.js
+++ b/tests/server/lib/scriptmanager.tests.js
@@ -17,13 +17,17 @@ describe('#scripts', () => {
     data = {
       scripts: {
         access: 'This is access script', // for reading
-        filter: 'function(ctx, callback) { callback(null, ctx.user.name); }', // for successful executing
+        filter: 'function(ctx, callback) { ctx.log("carlos here"); callback(null, ctx.user.name); }', // for
+        // successful
+        // executing
         create: '', // for writing
         memberships: 'function (ctx, callback) { callback(new Error("MembershipsError")); }', // for error return
         settings: 'function (ctx, callback) { console.log(ctx.user.name); callback(); }' // for error catch
       }
     };
     scriptmanager = new ScriptManager(storage);
+    const skipCache = name => scriptmanager.get(name);
+    scriptmanager.getCached = skipCache;
   });
 
   describe('#ScriptManager', () => {
@@ -44,11 +48,13 @@ describe('#scripts', () => {
       scriptmanager.execute('filter', conext).then(result => {
         expect(result).toEqual('PassedTest');
         done();
+      }).catch(e => {
+        done(e)
       });
     });
 
     it('should execute script and return error', (done) => {
-      scriptmanager.execute('memberships', {}).catch(error => {
+      scriptmanager.execute('memberships', {}).then(() => done('bad then')).catch(error => {
         expect(error.message).toEqual('MembershipsError');
         done();
       });

--- a/tests/server/routes/html.tests.js
+++ b/tests/server/routes/html.tests.js
@@ -12,7 +12,7 @@ const req = {
   originalUrl: '/login'
 };
 
-describe.only('# /html', () => {
+describe('# /html', () => {
   process.env.CLIENT_VERSION = '1.0';
 
   it('should return html with default values', (done) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -465,9 +465,9 @@ auth0-extension-tools@1.3.3, auth0-extension-tools@^1.3.0:
     superagent "^2.2.0"
     webtask-tools "^3.2.0"
 
-auth0-extension-ui@^1.1.9:
-  version "1.1.9"
-  resolved "https://registry.yarnpkg.com/auth0-extension-ui/-/auth0-extension-ui-1.1.9.tgz#5d446634bf9c8c8dfa66b24d77d9492eb343a439"
+auth0-extension-ui@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/auth0-extension-ui/-/auth0-extension-ui-1.2.2.tgz#5c336af2a02e9cc1a4924b6d903ae42626397234"
   dependencies:
     babel-runtime "^6.11.6"
     cross-env "^5.1.3"


### PR DESCRIPTION
## ✏️ Changes
  
Add the ability to remove menu items from the User Details action menu by setting `edit: false` for the following properties:
* "Delete User" => `property: "delete"`
* "Reset Password" => `property: "resetPassword"` (NOTE: this used to be hidden when property "password" was set to false, but that removes the ability to remove "just this one").  This is *not* backwards compatible.  It could be made backwards compatible by overriding "password" edit: false with a "resetPassword" edit: true.

Also fixed a bunch of unit tests.

## 📷 Screenshots
 
Screenshot seems overkill for just a missing menu item, it can be found on request though.
  
## 🔗 References
  
None, discussed in a meeting with the customer.
  
## 🎯 Testing
  
> Describe how this can be tested by reviewers. Please be specific about anything not tested and reasons why
You can also test this by creating userFields for property="password", "resetPassword", and "delete" with `edit: false`.  You should see the associated menu items from the action menu disappear.
> - Make sure you add unit and integration tests.
Added unit tests
> - If this is on a hot path, add load or performance tests
N/A
> - Especially for dependency updates we also need to make sure that there is no impact on performance.
None added
   
🚫 This change has been tested in a Webtask
 
✅This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅This can be deployed any time
  
## 🎡 Rollout
  
> Explain how the change will be verified once released. Manual testing? Functional testing?
  
In order to verify that the deployment was successful we will manually test
  
## 🔥 Rollback
  
> Explain when and why we will rollback the change.
  
We will rollback if customers have issues or the deployment tests fail
  
### 📄 Procedure
  
> Explain how the rollback for this change will look like, how we can recover fast.

Simply rebuild the old version and push with a new patch version number.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
This is code that works with other menu items, it is extremely unlikely to have an issue on the appliance that doesn't already exist.