### PR TITLE
Move Code Climate Reporter Id to Circle dashboard env var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,10 +17,7 @@ references:
       at: *workspace_root
 
 jobs:
-  build_and_test:
-    environment:
-      CC_TEST_REPORTER_ID: 707f5959816d898ffc7176d49d2cd4f6b200c697460965a77d7af28ffdcf5cb6
-    
+  build_and_test:    
     working_directory: *workspace_root
     <<: *node_container
 


### PR DESCRIPTION
## ✏️ Changes
  
`CC_TEST_REPORTER_ID` moved from circle script to dashboard to make config file more portable.