### PR TITLE
Revert "Move Code Climate Reporter Id to Circle dashboard env var"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,10 @@ references:
       at: *workspace_root
 
 jobs:
-  build_and_test:    
+  build_and_test:
+    environment:
+      CC_TEST_REPORTER_ID: 707f5959816d898ffc7176d49d2cd4f6b200c697460965a77d7af28ffdcf5cb6
+    
     working_directory: *workspace_root
     <<: *node_container
 


### PR DESCRIPTION
Reverts auth0-extensions/auth0-delegated-administration-extension#139

Reason: moving the env var to circle prevents us from passing it in to forked builds. This does not allow us to be able to run coverage reports on forked pull requests.