### PR TITLE
Connection field proper hiding / showing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- `Connection` field will be hidden, if there is only one connection. #155
+- `Connection` field now properly showing connection name, if there are more than one connection.
+
 ## [3.4.0] - 2018-10-25
 
 ### Added

--- a/client/containers/Users/Dialogs/EmailChangeDialog.jsx
+++ b/client/containers/Users/Dialogs/EmailChangeDialog.jsx
@@ -15,6 +15,7 @@ import getErrorMessage from '../../../utils/getErrorMessage';
 
 export default connectContainer(class extends Component {
   static stateToProps = (state) => ({
+    connections: state.connections,
     emailChange: state.emailChange,
     settings: (state.settings.get('record') && state.settings.get('record').toJS().settings) || {},
     languageDictionary: state.languageDictionary
@@ -28,6 +29,7 @@ export default connectContainer(class extends Component {
   static propTypes = {
     cancelEmailChange: PropTypes.func.isRequired,
     changeEmail: PropTypes.func.isRequired,
+    connections: PropTypes.object.isRequired,
     emailChange: PropTypes.object.isRequired
   };
 
@@ -47,7 +49,7 @@ export default connectContainer(class extends Component {
   };
 
   render() {
-    const { cancelEmailChange, settings } = this.props;
+    const { cancelEmailChange, settings, connections } = this.props;
     const { user, connection, error, requesting, loading } = this.props.emailChange.toJS();
 
     const userFields = settings.userFields || [];
@@ -61,7 +63,7 @@ export default connectContainer(class extends Component {
 
     const fields = _.cloneDeep(userFields) || [];
     useEmailField(true, fields);
-    useDisabledConnectionField(true, fields, connection);
+    useDisabledConnectionField(true, fields, connection, connections.get('records').toJS());
 
     const allowedFields = ['email', 'connection'];
     const filteredFields = _.filter(fields,

--- a/client/containers/Users/Dialogs/PasswordChangeDialog.jsx
+++ b/client/containers/Users/Dialogs/PasswordChangeDialog.jsx
@@ -18,6 +18,7 @@ import getErrorMessage from '../../../utils/getErrorMessage';
 
 export default connectContainer(class PasswordChangeDialog extends Component {
   static stateToProps = (state) => ({
+    connections: state.connections,
     passwordChange: state.passwordChange,
     settings: (state.settings.get('record') && state.settings.get('record').toJS().settings) || {},
     languageDictionary: state.languageDictionary
@@ -29,6 +30,7 @@ export default connectContainer(class PasswordChangeDialog extends Component {
   };
 
   static propTypes = {
+    connections: PropTypes.object.isRequired,
     passwordChange: PropTypes.object.isRequired,
     changePassword: PropTypes.func.isRequired,
     cancelPasswordChange: PropTypes.func.isRequired
@@ -49,7 +51,7 @@ export default connectContainer(class PasswordChangeDialog extends Component {
   };
 
   render() {
-    const { cancelPasswordChange, settings } = this.props;
+    const { cancelPasswordChange, settings, connections } = this.props;
     const { connection, user, error, requesting, loading } = this.props.passwordChange.toJS();
 
     const userFields = settings.userFields || [];
@@ -68,7 +70,7 @@ export default connectContainer(class PasswordChangeDialog extends Component {
 
     const fields = _.cloneDeep(userFields) || [];
     usePasswordFields(true, fields);
-    useDisabledConnectionField(true, fields, connection);
+    useDisabledConnectionField(true, fields, connection, connections.get('records').toJS());
     useDisabledEmailField(true, fields);
 
     const allowedFields = ['email', 'connection', 'password', 'repeatPassword'];

--- a/client/containers/Users/Dialogs/PasswordResetDialog.jsx
+++ b/client/containers/Users/Dialogs/PasswordResetDialog.jsx
@@ -20,6 +20,7 @@ import getErrorMessage from '../../../utils/getErrorMessage';
 
 export default connectContainer(class extends Component {
   static stateToProps = (state) => ({
+    connections: state.connections,
     passwordReset: state.passwordReset,
     appsForConnection: getAppsForConnection(state),
     settings: (state.settings.get('record') && state.settings.get('record').toJS().settings) || {},
@@ -34,6 +35,7 @@ export default connectContainer(class extends Component {
   static propTypes = {
     cancelPasswordReset: PropTypes.func.isRequired,
     resetPassword: PropTypes.func.isRequired,
+    connections: PropTypes.object.isRequired,
     passwordReset: PropTypes.object.isRequired,
     appsForConnection: PropTypes.object
   };
@@ -54,7 +56,7 @@ export default connectContainer(class extends Component {
   };
 
   render() {
-    const { cancelPasswordReset, settings } = this.props;
+    const { cancelPasswordReset, settings, connections } = this.props;
     const { connection, user, error, requesting, loading } = this.props.passwordReset.toJS();
 
     if (!requesting) {
@@ -72,7 +74,7 @@ export default connectContainer(class extends Component {
 
     const fields = _.cloneDeep(userFields) || [];
     useClientField(true, fields, this.props.appsForConnection.toJS());
-    useDisabledConnectionField(true, fields, connection);
+    useDisabledConnectionField(true, fields, connection, connections.get('records').toJS());
     useDisabledEmailField(true, fields);
 
     const allowedFields = ['email', 'client', 'connection'];

--- a/client/containers/Users/Dialogs/UsernameChangeDialog.jsx
+++ b/client/containers/Users/Dialogs/UsernameChangeDialog.jsx
@@ -27,6 +27,7 @@ export default connectContainer(class extends Component {
   static propTypes = {
     cancelUsernameChange: PropTypes.func.isRequired,
     changeUsername: PropTypes.func.isRequired,
+    connections: PropTypes.object.isRequired,
     usernameChange: PropTypes.object.isRequired
   };
 
@@ -66,7 +67,7 @@ export default connectContainer(class extends Component {
     const initialValues = mapValues(user, allowedFields, userFields, 'edit', languageDictionary);
     const fields = _.cloneDeep(userFields) || [];
     useUsernameField(true, fields, connections.get('records').toJS(), connection, initialValues);
-    useDisabledConnectionField(true, fields, connection);
+    useDisabledConnectionField(true, fields, connection, connections.get('records').toJS());
 
     const filteredFields = _.filter(fields,
       field => _.includes(allowedFields, field.property));

--- a/client/utils/useDefaultFields.js
+++ b/client/utils/useDefaultFields.js
@@ -94,9 +94,10 @@ export const useMfaField = (isEditField, fields, providers, onProviderChange) =>
   return applyDefaults(type, fields, 'multifactor', defaults);
 };
 
-export const useDisabledConnectionField = (isEditField, fields, connection) => {
+export const useDisabledConnectionField = (isEditField, fields, connection, connections) => {
   const type = isEditField ? 'edit' : 'create';
-  if (!connection) {
+
+  if (!connection || !connections || connections.length < 2) {
     return _.remove(fields, { property: 'connection' });
   }
 

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -267,6 +267,8 @@ export default (storage, scriptManager) => {
           return data;
         }
 
+        data.user.connection = name;
+
         return getConnectionIdByName(req.auth0, name)
           .then((connectionId) => {
             if (connectionId) {

--- a/tests/client/containers/Users/Dialogs/EmailChangeDialog.tests.js
+++ b/tests/client/containers/Users/Dialogs/EmailChangeDialog.tests.js
@@ -31,6 +31,9 @@ describe('#Client-Containers-Users-Dialogs-EmailChangeDialog', () => {
         requesting: true,
         loading: false
       }),
+      connections: fromJS({
+        records: options.connections || [ { name: 'connA' }, { name: 'connB' } ]
+      }),
       languageDictionary: fromJS({
         record: languageDictionary || {}
       }),

--- a/tests/client/containers/Users/Dialogs/PasswordChangeDialog.tests.js
+++ b/tests/client/containers/Users/Dialogs/PasswordChangeDialog.tests.js
@@ -27,6 +27,9 @@ describe('#Client-Containers-Users-Dialogs-PasswordChangeDialog', () => {
         requesting: true,
         loading: false
       }),
+      connections: fromJS({
+        records: options.connections || [ { name: 'connA' }, { name: 'connB' } ]
+      }),
       languageDictionary: fromJS({
         record: languageDictionary || {}
       }),

--- a/tests/client/containers/Users/Dialogs/PasswordResetDialog.tests.js
+++ b/tests/client/containers/Users/Dialogs/PasswordResetDialog.tests.js
@@ -32,11 +32,7 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       }),
       settings: fromJS(options.settings || {}),
       connections: fromJS({
-        records: [
-          {
-            name: 'connA'
-          }
-        ]
+        records: options.connections || [ { name: 'connA' }, { name: 'connB' } ]
       }),
       user: fromJS({
         connection: {
@@ -111,6 +107,17 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
     checkText(component, 'Do you really want to reset the password for ', 'bill', '? This will send an email to the' +
       ' user allowing them to choose a new password.');
     checkConnectionLabel(component, 'Connection');
+    checkEmailLabel(component, 'Email');
+    checkClientLabel(component, 'Client (required)');
+    checkConfirm(component, 'Reset Password?');
+  });
+
+  it('should render without connection field', () => {
+    const component = renderComponent({ username: 'bill', connections: [ { name: 'connA' } ] });
+
+    checkText(component, 'Do you really want to reset the password for ', 'bill', '? This will send an email to the' +
+      ' user allowing them to choose a new password.');
+    checkConnectionLabel(component);
     checkEmailLabel(component, 'Email');
     checkClientLabel(component, 'Client (required)');
     checkConfirm(component, 'Reset Password?');

--- a/tests/client/containers/Users/Dialogs/UsernameChangeDialog.tests.js
+++ b/tests/client/containers/Users/Dialogs/UsernameChangeDialog.tests.js
@@ -27,7 +27,9 @@ describe('#Client-Containers-Users-Dialogs-UsernameChangeDialog', () => {
         loading: false,
         connection: 'connA'
       }),
-      connections: fromJS({ records: [{ name: 'connA', options: { requires_username: true }}]}),
+      connections: fromJS({
+        records: options.connections || [ { name: 'connA', options: { requires_username: true } }, { name: 'connB' } ]
+      }),
       languageDictionary: fromJS({
         record: languageDictionary || {}
       }),
@@ -86,6 +88,19 @@ describe('#Client-Containers-Users-Dialogs-UsernameChangeDialog', () => {
     checkConfirm(component, 'Change Username?');
   });
 
+  it('should render without connection field', () => {
+    const component = renderComponent(
+      {
+        username: 'bill',
+        connections: [ { name: 'connA', options: { requires_username: true } } ]
+      });
+
+    checkText(component, 'Do you really want to change the username for ', 'bill', '?');
+    checkConnectionLabel(component);
+    checkUsernameLabel(component, 'Username (required)');
+    checkConfirm(component, 'Change Username?');
+  });
+
   it('should render not applicable language dictionary', () => {
     const component = renderComponent({ username: 'bill' }, { someKey: 'someValue' });
 
@@ -109,7 +124,7 @@ describe('#Client-Containers-Users-Dialogs-UsernameChangeDialog', () => {
     const languageDictionary = {
       changeUsernameMessage: 'Some other message {   username    }something else'
     };
-    const component = renderComponent({username:'sally'}, languageDictionary);
+    const component = renderComponent({ username: 'sally' }, languageDictionary);
 
     checkText(component, 'Some other message ', 'sally', 'something else');
   });
@@ -118,7 +133,7 @@ describe('#Client-Containers-Users-Dialogs-UsernameChangeDialog', () => {
     const languageDictionary = {
       changeUsernameMessage: 'no username included: '
     };
-    const component = renderComponent({username:'john'}, languageDictionary);
+    const component = renderComponent({ username: 'john' }, languageDictionary);
 
     checkText(component, 'no username included: ', 'john', '');
   });
@@ -142,7 +157,7 @@ describe('#Client-Containers-Users-Dialogs-UsernameChangeDialog', () => {
         }
       }
     };
-    const component = renderComponent({username:'john', settings});
+    const component = renderComponent({ username: 'john', settings });
     checkConnectionLabel(component);
 
   });
@@ -166,7 +181,7 @@ describe('#Client-Containers-Users-Dialogs-UsernameChangeDialog', () => {
         }
       }
     };
-    const component = renderComponent({username:'john', settings});
+    const component = renderComponent({ username: 'bill', settings });
     checkConnectionLabel(component, 'ConnectionLabel');
 
   });
@@ -189,8 +204,7 @@ describe('#Client-Containers-Users-Dialogs-UsernameChangeDialog', () => {
         }
       }
     };
-    const component = renderComponent({username:'john', settings});
+    const component = renderComponent({ username: 'bill', settings });
     checkConnectionLabel(component, 'Connection');
-
   });
 });

--- a/tests/client/utils/useDefaultFields.tests.js
+++ b/tests/client/utils/useDefaultFields.tests.js
@@ -329,6 +329,7 @@ describe('Client-Utils-useDefaultFields', () => {
 
   describe('#useDisabledConnectionField', () => {
     const connection = 'connA';
+    const connections = [ 'connA', 'connB' ];
     const standardTarget = (type) => ({
       property: 'connection',
       label: 'Connection',
@@ -342,7 +343,15 @@ describe('Client-Utils-useDefaultFields', () => {
       const fields = [];
       const target = [standardTarget('edit')];
 
-      useDefaultFields.useDisabledConnectionField(true, fields, connection);
+      useDefaultFields.useDisabledConnectionField(true, fields, connection, connections);
+      expect(fields).to.deep.equal(target);
+    });
+
+    it('empty array population with single connection', () => {
+      const fields = [];
+      const target = [];
+
+      useDefaultFields.useDisabledConnectionField(true, fields, connection, [ 'connA' ]);
       expect(fields).to.deep.equal(target);
     });
 
@@ -365,7 +374,7 @@ describe('Client-Utils-useDefaultFields', () => {
       }];
       const target = [standardTarget('create')];
 
-      useDefaultFields.useDisabledConnectionField(false, fields, connection);
+      useDefaultFields.useDisabledConnectionField(false, fields, connection, connections);
       expect(fields).to.deep.equal(target);
     });
 
@@ -380,7 +389,7 @@ describe('Client-Utils-useDefaultFields', () => {
       }];
       const target = [_.assign({}, standardTarget('create'), { label: 'ConnectionsLabel' })];
 
-      useDefaultFields.useDisabledConnectionField(false, fields, connection);
+      useDefaultFields.useDisabledConnectionField(false, fields, connection, connections);
       expect(fields).to.deep.equal(target);
     });
 
@@ -392,7 +401,7 @@ describe('Client-Utils-useDefaultFields', () => {
       }];
       const target = [];
 
-      useDefaultFields.useDisabledConnectionField(true, fields, connection);
+      useDefaultFields.useDisabledConnectionField(true, fields, connection, connections);
       expect(fields).to.deep.equal(target);
     });
 


### PR DESCRIPTION
## ✏️ Changes
Fixes #155 
The disabled `Connection` field in `Change*` dialogs was broken and didn't display connection name. Fixed by adding connections name to the user object, where redux-form can access its value.
Added check for total connections number, to hide the `Connection` field, if there is only one connection exists.
  
## 📷 Screenshots
One connection:
![screen shot 2018-12-14 at 14 34 40](https://user-images.githubusercontent.com/20518477/50005349-bf16bc80-ffb2-11e8-9e80-e91848855211.png)
Two connections:
![screen shot 2018-12-14 at 14 35 20](https://user-images.githubusercontent.com/20518477/50005350-bfaf5300-ffb2-11e8-9634-4ddf426ca57c.png)

  
## 🔗 References
Jira: https://auth0team.atlassian.net/browse/KEY-688
GH Issue: #155 
  
## 🎯 Testing
✅ This change has been tested locally
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
 