### PR TITLE
fixed removeMfa to handle any non-duo/google provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- `Remove MFA` for `any` provider.
+
 ## [3.4.1] - 2019-01-04
 
 ### Fixed

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -538,7 +538,7 @@ export default (storage, scriptManager) => {
     const provider = req.params.provider;
     const userId = req.params.id;
 
-    if (provider !== 'guardian') {
+    if (provider === 'duo' || provider === 'google-authenticator') {
       req.auth0.users.deleteMultifactorProvider({ id: userId, provider })
         .then(() => res.sendStatus(204))
         .catch(next);


### PR DESCRIPTION
## ✏️ Changes
Now extension will use `deleteMultifactorProvider` only for supported providers (duo/google), and `removeGuardian` for any other providers.
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1547102000093500
  
## 🎯 Testing
✅ This change has been tested locally
🚫 This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  