### PR TITLE
Feature/disable create user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- `canCreateUser` property added to the `settings` hook. It is `true` by default.
+
 ## [3.4.2] - 2019-01-17
 
 ### Fixed

--- a/client/containers/Users/Users.jsx
+++ b/client/containers/Users/Users.jsx
@@ -89,6 +89,7 @@ class Users extends Component {
     } = this.props;
 
     const userFields = (settings && settings.userFields) || [];
+    const showCreateUser = settings.canCreateUser !== undefined ? settings.canCreateUser: true;
     const role = accessLevel.get('record').get('role');
     const originalTitle = (settings.dict && settings.dict.title) || window.config.TITLE || 'User Management';
     document.title = `${languageDictionary.userUsersTabTitle || 'Users'} - ${originalTitle}`;
@@ -101,7 +102,7 @@ class Users extends Component {
         <div className="row content-header">
           <div className="col-xs-12 user-table-content">
             <h1>{languageDictionary.usersTitle || 'Users'}</h1>
-            {(connections.length && role > 0) ?
+            {(connections.length && role > 0 && showCreateUser) ?
               <button id="create-user-button" className="btn btn-success pull-right new" onClick={this.createUser}>
                 <i className="icon-budicon-473"></i>
                 {languageDictionary.createUserButtonText || 'Create User'}

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -3,7 +3,7 @@ import auth0 from 'auth0';
 import request from 'request';
 import Promise from 'bluebird';
 import { Router } from 'express';
-import { ArgumentError, ValidationError } from 'auth0-extension-tools';
+import { ArgumentError, ValidationError, UnauthorizedError } from 'auth0-extension-tools';
 
 import config from '../lib/config';
 import logger from '../lib/logger';
@@ -133,6 +133,11 @@ export default (storage, scriptManager) => {
           },
           userFields
         };
+
+        const canCreateUser = settings.canCreateUser !== undefined ? settings.canCreateUser: true;
+        if (canCreateUser === false) {
+          return next(new UnauthorizedError('Create user is forbidden'));
+        }
 
         const repeatPasswordField = _.find(userFields, { property: 'repeatPassword' });
         if (!repeatPasswordField) {

--- a/tests/client/containers/Users/Users.tests.js
+++ b/tests/client/containers/Users/Users.tests.js
@@ -27,7 +27,7 @@ class UsersWrapper extends Component {
 
 describe('#Client-Containers-Users-Users', () => {
 
-  const renderComponent = (languageDictionary) => {
+  const renderComponent = (languageDictionary, settings = {}) => {
     const initialState = {
       connections: fromJS({ records: [{name: 'connA'}]}),
       accessLevel: fromJS({ record: { role: 1 } }),
@@ -54,7 +54,7 @@ describe('#Client-Containers-Users-Users', () => {
       languageDictionary: fromJS({
         record: languageDictionary || {}
       }),
-      settings: fromJS({ record: { settings: {} } })
+      settings: fromJS({ record: { settings: settings || {} } })
     };
     return wrapperMount(
       <Provider store={fakeStore(initialState)}>
@@ -97,6 +97,11 @@ describe('#Client-Containers-Users-Users', () => {
     expect(buttonObject.text()).to.equal(createButtonText);
   };
 
+  const checkCreateUserButtonMissing = (component) => {
+    const buttonObject = component.find('#create-user-button');
+    expect(buttonObject.length).to.equal(0);
+  };
+
   it('should render', () => {
     const component = renderComponent();
 
@@ -123,5 +128,17 @@ describe('#Client-Containers-Users-Users', () => {
     checkAllComponentsForLanguageDictionary(component, languageDictionary);
     checkCreateButtonText(component, 'Create User Text');
     checkTitle(component, 'Users Title');
+  });
+
+  it('should not show "Create User" button', () => {
+    const languageDictionary = {
+      createUserButtonText: 'Create User Text',
+      usersTitle: 'Users Title'
+    };
+    const component = renderComponent(languageDictionary, {
+      canCreateUser: false
+    });
+
+    checkCreateUserButtonMissing(component);
   });
 });

--- a/tests/server/routes/users.tests.js
+++ b/tests/server/routes/users.tests.js
@@ -230,6 +230,25 @@ describe('#users router', () => {
     callback(null, result);
   }).toString();
 
+  const settingsWithUserCreateDisabled = ((ctx, callback) => {
+    var result = {
+      connections: ['conn-a', 'conn-b'],
+      dict: {
+        title: ctx.request.user.email + ' dashboard',
+        memberships: 'Groups'
+      },
+      css: 'http://localhost:3001/app/default.css',
+      userFields: [
+        {
+          property: "email",
+          label: "Email"
+        }
+      ],
+      canCreateUser: false
+    };
+    callback(null, result);
+  }).toString();
+
   const app = express();
 
   app.use(bodyParser.json());
@@ -442,6 +461,24 @@ describe('#users router', () => {
           done();
         });
     });
+
+    it('should return "Unauthorized error"', (done) => {
+      const newUser = {
+        email: 'user7@example.com',
+        memberships: ['deptC']
+      };
+      scriptManager.getCached = skipCache;
+      storage.data.scripts.settings = settingsWithUserCreateDisabled;
+
+      request(app)
+        .post('/users')
+        .send(newUser)
+        .expect(401)
+        .end((err) => {
+          if (err) return done(err);
+          done();
+        });
+    })
   });
 
   describe('#Delete', () => {


### PR DESCRIPTION
## ✏️ Changes
  These changes are made by @SumanaMalkapuram on customers request. `canCreateUsers` flag is added to the `settings` hook to simplify disabling this functionality. `canCreateUsers` is `true` by default, so these changes wont affect current settings.
  
## 🔗 References
  Slack: https://auth0.slack.com/archives/C9170558S/p1547743992194400
  
## 🎯 Testing
🚫 This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  