### PR TITLE
Empty settings bug fix (user creation)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.4] - 2019-02-11
+
+### Fixed
+- Create user with empty `settings query` bug fixed.
+
 ## [3.4.3] - 2019-01-24
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "description": "Delegated Administration Dashboard",
   "engines": {
     "node": ">8.9"

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -117,7 +117,8 @@ export default (storage, scriptManager) => {
 
     scriptManager.execute('settings', settingsContext)
       .then((settings) => {
-        const userFields = settings && settings.userFields;
+        settings = settings || {};
+        const userFields = settings.userFields;
         const createContext = {
           method: 'create',
           request: {

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Delegated Administration Dashboard",
   "name": "auth0-delegated-admin",
-  "version": "3.4.3",
+  "version": "3.4.4",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",


### PR DESCRIPTION
## ✏️ Changes
  In recent update `canCreateUsers` flag was added to the `settings` object, but there was no check for object to exist. Added empty object as a default value for `settings` in these changes. 
   
## 🔗 References
  Support ticket: https://auth0.lightning.force.com/lightning/r/Case/5001G00000bu3KTQAY/view
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  