### PR TITLE
Password reset fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.6] - Unreleased
+
+### Fixed
+- Fixed bug which doesn't allow to override client field for `reset password` action
+
 ## [3.4.5] - 2019-02-21
 
 ### Added

--- a/client/actions/user.js
+++ b/client/actions/user.js
@@ -422,12 +422,13 @@ export function cancelPasswordReset() {
 export function resetPassword(application) {
   return (dispatch, getState) => {
     const { user: { user_id }, connection } = getState().passwordReset.toJS();
+    const clientId = application.client.value || application.client;
     dispatch({
       type: constants.PASSWORD_RESET,
       payload: {
         promise: axios.post(`/api/users/${user_id}/password-reset`, {
           connection,
-          clientId: application.client
+          clientId
         })
       },
       meta: {


### PR DESCRIPTION
## ✏️ Changes
  Due to bug, it was impossible to override `client` field for `reset password` action using `userFields`. Fixes #154
  
## 🔗 References
  Github: #154
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  