### PR TITLE
custom domains support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## Unreleased
+
+### Added
+- Custom domains support
+
 ## [3.5.0] - 2019-03-20
 
 ### Added

--- a/client/actions/auth.js
+++ b/client/actions/auth.js
@@ -4,19 +4,22 @@ import { push } from 'react-router-redux';
 
 import * as constants from '../constants';
 
-const issuer = window.config.AUTH0_TOKEN_ISSUER || `https://${window.config.AUTH0_DOMAIN}/`;
-
-const webAuth = new auth0.WebAuth({ // eslint-disable-line no-undef
-  domain: window.config.AUTH0_DOMAIN,
+const webAuthOptions = {
+  domain: window.config.AUTH0_CUSTOM_DOMAIN || window.config.AUTH0_DOMAIN,
   clientID: window.config.AUTH0_CLIENT_ID,
-  overrides: {
-    __tenant: issuer.substr(8).split('.')[0],
-    __token_issuer: issuer
-  },
   scope: 'openid roles',
   responseType: 'id_token',
   redirectUri: `${window.config.BASE_URL}/login`
-});
+};
+
+if (window.config.IS_APPLIANCE) {
+  webAuthOptions.overrides = {
+    __tenant: window.config.AUTH0_DOMAIN.split('.')[0],
+    __token_issuer: `https://${window.config.AUTH0_DOMAIN}/`
+  };
+}
+
+const webAuth = new auth0.WebAuth(webAuthOptions); // eslint-disable-line no-undef
 
 export function login(returnUrl, locale) {
   sessionStorage.setItem('delegated-admin:returnTo', returnUrl || '/users');

--- a/server/index.js
+++ b/server/index.js
@@ -40,11 +40,11 @@ module.exports = (cfg, storageProvider) => {
     secret: config('EXTENSION_SECRET'),
     audience: 'urn:delegated-admin',
     rta: config('AUTH0_RTA').replace('https://', ''),
-    domain: config('AUTH0_ISSUER_DOMAIN'),
+    domain: config('AUTH0_DOMAIN'),
     baseUrl: config('PUBLIC_WT_URL'),
     webtaskUrl: config('PUBLIC_WT_URL'),
     clientName: 'Delegated Administration',
-    noAccessToken : true,
+    noAccessToken: true,
     urlPrefix: '/admins',
     sessionStorageKey: 'delegated-admin:apiToken',
     scopes: 'read:clients delete:clients read:connections read:users update:users delete:users create:users read:logs read:device_credentials update:device_credentials delete:device_credentials delete:guardian_enrollments'

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -1,23 +1,27 @@
 const config = require('auth0-extension-tools').config();
 
-const daeConfig = function(key) {
-  if (key === 'AUTH0_ISSUER_DOMAIN') {
-    return config('AUTH0_ISSUER_DOMAIN') || config('AUTH0_DOMAIN');
+const daeConfig = function (key) {
+  if (key === 'AUTH0_CUSTOM_DOMAIN') {
+    return config('AUTH0_CUSTOM_DOMAIN') || config('AUTH0_DOMAIN');
+  }
+
+  if (key === 'IS_APPLIANCE') {
+    return config('AUTH0_RTA') && config('AUTH0_RTA').replace('https://', '') === 'auth0.auth0.com';
   }
 
   return config(key);
 };
 
-daeConfig.getValue = function(key) {
+daeConfig.getValue = function (key) {
   return config(key);
-}
+};
 
-daeConfig.setValue = function(key, value) {
+daeConfig.setValue = function (key, value) {
   return config.setValue(key, value);
-}
+};
 
-daeConfig.setProvider = function(provider) {
+daeConfig.setProvider = function (provider) {
   return config.setProvider(provider);
-}
+};
 
 module.exports = daeConfig;

--- a/server/lib/config.js
+++ b/server/lib/config.js
@@ -6,7 +6,7 @@ const daeConfig = function (key) {
   }
 
   if (key === 'IS_APPLIANCE') {
-    return config('AUTH0_RTA') && config('AUTH0_RTA').replace('https://', '') === 'auth0.auth0.com';
+    return config('AUTH0_RTA') && config('AUTH0_RTA').replace('https://', '') !== 'auth0.auth0.com';
   }
 
   return config(key);

--- a/server/lib/getApiToken.js
+++ b/server/lib/getApiToken.js
@@ -8,5 +8,5 @@ export default (req) => {
     return new Promise(resolve => resolve(req.user.access_token));
   }
 
-  return managementApi.getAccessTokenCached(config('AUTH0_ISSUER_DOMAIN'), config('AUTH0_CLIENT_ID'), config('AUTH0_CLIENT_SECRET'));
+  return managementApi.getAccessTokenCached(config('AUTH0_DOMAIN'), config('AUTH0_CLIENT_ID'), config('AUTH0_CLIENT_SECRET'));
 }

--- a/server/lib/removeGuardian.js
+++ b/server/lib/removeGuardian.js
@@ -10,7 +10,7 @@ const requestClearGuardian = (token, enrollmentId) =>
     }
 
     return request
-      .del(`https://${config('AUTH0_ISSUER_DOMAIN')}/api/v2/guardian/enrollments/${enrollmentId}`)
+      .del(`https://${config('AUTH0_DOMAIN')}/api/v2/guardian/enrollments/${enrollmentId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('Content-Type', 'application/json')
       .end((err) => {
@@ -25,7 +25,7 @@ const requestClearGuardian = (token, enrollmentId) =>
 export const requestGuardianEnrollments = (token, userId) =>
   new Promise((resolve, reject) => {
     request
-      .get(`https://${config('AUTH0_ISSUER_DOMAIN')}/api/v2/users/${userId}/enrollments`)
+      .get(`https://${config('AUTH0_DOMAIN')}/api/v2/users/${userId}/enrollments`)
       .set('Authorization', `Bearer ${token}`)
       .set('Content-Type', 'application/json')
       .end((err, res) => {

--- a/server/lib/userBlocks.js
+++ b/server/lib/userBlocks.js
@@ -6,7 +6,7 @@ import config from './config';
 export const requestUserBlocks = (token, userId) =>
   new Promise((resolve, reject) => {
     request
-      .get(`https://${config('AUTH0_ISSUER_DOMAIN')}/api/v2/user-blocks/${userId}`)
+      .get(`https://${config('AUTH0_DOMAIN')}/api/v2/user-blocks/${userId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('Content-Type', 'application/json')
       .end((err, res) => {
@@ -22,7 +22,7 @@ export const requestUserBlocks = (token, userId) =>
 export const removeUserBlocks = (token, userId) =>
   new Promise((resolve, reject) => {
     request
-      .del(`https://${config('AUTH0_ISSUER_DOMAIN')}/api/v2/user-blocks/${userId}`)
+      .del(`https://${config('AUTH0_DOMAIN')}/api/v2/user-blocks/${userId}`)
       .set('Authorization', `Bearer ${token}`)
       .set('Content-Type', 'application/json')
       .end((err, res) => {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -68,7 +68,7 @@ export default (storage) => {
 
   // Allow end users to authenticate.
   api.use(middlewares.authenticateUsers.optional({
-    domain: config('AUTH0_ISSUER_DOMAIN'),
+    domain: config('AUTH0_CUSTOM_DOMAIN'),
     audience: config('EXTENSION_CLIENT_ID'),
     credentialsRequired: false,
     onLoginSuccess: (req, res, next) => {

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -21,7 +21,7 @@ import users from './users';
 export default (storage) => {
   const scriptManager = new ScriptManager(storage);
   const managementApiClient = middlewares.managementApiClient({
-    domain: config('AUTH0_ISSUER_DOMAIN'),
+    domain: config('AUTH0_DOMAIN'),
     clientId: config('AUTH0_CLIENT_ID'),
     clientSecret: config('AUTH0_CLIENT_SECRET')
   });
@@ -47,13 +47,13 @@ export default (storage) => {
     if (!token) console.error('no token found');
 
     const promise = tools.managementApi.getClient({
-      domain: config('AUTH0_ISSUER_DOMAIN'),
+      domain: config('AUTH0_DOMAIN'),
       clientId: config('AUTH0_CLIENT_ID'),
       clientSecret: config('AUTH0_CLIENT_SECRET')
     })
       .then(auth0 =>
         auth0.users.get({ id: user.sub })
-          .then(userData => {
+          .then((userData) => {
             _.assign(user, userData);
             user.token = token;
             global.daeUser[user.sub] = user;
@@ -80,7 +80,6 @@ export default (storage) => {
           return next();
         })
         .catch(next);
-
     }
   }));
 
@@ -95,7 +94,7 @@ export default (storage) => {
       return addExtraUserInfo(getToken(req), req.user)
         .then((user) => {
           currentRequest.user = user;
-          currentRequest.user.scope = [constants.AUDITOR_PERMISSION, constants.USER_PERMISSION, constants.ADMIN_PERMISSION];
+          currentRequest.user.scope = [ constants.AUDITOR_PERMISSION, constants.USER_PERMISSION, constants.OPERATOR_PERMISSION, constants.ADMIN_PERMISSION ];
           return next();
         })
         .catch(next);

--- a/server/routes/hooks.js
+++ b/server/routes/hooks.js
@@ -7,12 +7,12 @@ import logger from '../lib/logger';
 
 export default () => {
   const hookValidator = middlewares
-    .validateHookToken(config('AUTH0_ISSUER_DOMAIN'), config('WT_URL'), config('EXTENSION_SECRET'));
+    .validateHookToken(config('AUTH0_DOMAIN'), config('WT_URL'), config('EXTENSION_SECRET'));
 
   const hooks = router();
   hooks.use('/on-uninstall', hookValidator('/.extensions/on-uninstall'));
   hooks.use(middlewares.managementApiClient({
-    domain: config('AUTH0_ISSUER_DOMAIN'),
+    domain: config('AUTH0_DOMAIN'),
     clientId: config('AUTH0_CLIENT_ID'),
     clientSecret: config('AUTH0_CLIENT_SECRET')
   }));

--- a/server/routes/html.js
+++ b/server/routes/html.js
@@ -73,7 +73,7 @@ export default () => {
     }
 
     const settings = {
-      AUTH0_DOMAIN: config('AUTH0_DOMAIN'),
+      AUTH0_DOMAIN: config('AUTH0_ISSUER_DOMAIN'),
       AUTH0_TOKEN_ISSUER: `https://${config('AUTH0_ISSUER_DOMAIN')}/`,
       AUTH0_CLIENT_ID: config('EXTENSION_CLIENT_ID'),
       EXTEND_URL: config('EXTEND_URL'),

--- a/server/routes/html.js
+++ b/server/routes/html.js
@@ -73,8 +73,9 @@ export default () => {
     }
 
     const settings = {
-      AUTH0_DOMAIN: config('AUTH0_ISSUER_DOMAIN'),
-      AUTH0_TOKEN_ISSUER: `https://${config('AUTH0_ISSUER_DOMAIN')}/`,
+      AUTH0_DOMAIN: config('AUTH0_DOMAIN'),
+      AUTH0_CUSTOM_DOMAIN: config('AUTH0_CUSTOM_DOMAIN'),
+      IS_APPLIANCE: config('IS_APPLIANCE'),
       AUTH0_CLIENT_ID: config('EXTENSION_CLIENT_ID'),
       EXTEND_URL: config('EXTEND_URL'),
       BASE_URL: urlHelpers.getBaseUrl(req),

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -511,7 +511,7 @@ export default (storage, scriptManager) => {
     getApiToken(req)
       .then((accessToken) => {
         const options = {
-          uri: `https://${config('AUTH0_ISSUER_DOMAIN')}/api/v2/users/${encodeURIComponent(req.params.id)}/logs`,
+          uri: `https://${config('AUTH0_DOMAIN')}/api/v2/users/${encodeURIComponent(req.params.id)}/logs`,
           qs: {
             include_totals: true
           },

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -365,7 +365,7 @@ export default (storage, scriptManager) => {
    */
   api.post('/:id/password-reset', verifyUserAccess('reset:password', scriptManager), (req, res, next) => {
     const client = new auth0.AuthenticationClient({
-      domain: config('AUTH0_ISSUER_DOMAIN'),
+      domain: config('AUTH0_DOMAIN'),
       clientId: config('AUTH0_CLIENT_ID')
     });
 

--- a/tests/server/lib/config.tests.js
+++ b/tests/server/lib/config.tests.js
@@ -8,34 +8,58 @@ import { defaultConfig } from '../../utils/dummyData';
 describe('config', () => {
   describe('#get', () => {
     it('should return setting from provider if configured', () => {
-      config.setProvider((key) => defaultConfig[key], null);
+      config.setProvider(key => defaultConfig[key], null);
 
       expect(config('AUTH0_DOMAIN')).to.equal(defaultConfig.AUTH0_DOMAIN);
     });
 
-    it('should use domain for issuer domain if none defined', () => {
-      config.setProvider((key) => defaultConfig[key], null);
+    it('should use domain for custom domain if none defined', () => {
+      config.setProvider(key => defaultConfig[key], null);
 
-      expect(config('AUTH0_ISSUER_DOMAIN')).to.equal(defaultConfig.AUTH0_DOMAIN);
+      expect(config('AUTH0_CUSTOM_DOMAIN')).to.equal(defaultConfig.AUTH0_DOMAIN);
     });
 
     it('should use issuer if defined', () => {
       const issuerConfig = _.cloneDeep(defaultConfig);
-      issuerConfig.AUTH0_ISSUER_DOMAIN = 'some_domain';
+      issuerConfig.AUTH0_CUSTOM_DOMAIN = 'some_domain';
 
-      config.setProvider((key) => issuerConfig[key], null);
+      config.setProvider(key => issuerConfig[key], null);
 
       expect(config('AUTH0_DOMAIN')).to.equal(defaultConfig.AUTH0_DOMAIN);
-      expect(config('AUTH0_ISSUER_DOMAIN')).to.equal(issuerConfig.AUTH0_ISSUER_DOMAIN);
+      expect(config('AUTH0_CUSTOM_DOMAIN')).to.equal(issuerConfig.AUTH0_CUSTOM_DOMAIN);
 
       // Put provider back or other tests fail!
-      config.setProvider((key) => defaultConfig[key], null);
+      config.setProvider(key => defaultConfig[key], null);
+    });
+
+    it('should detect appliance', () => {
+      const issuerConfig = _.cloneDeep(defaultConfig);
+      issuerConfig.AUTH0_RTA = 'example.com';
+
+      config.setProvider(key => issuerConfig[key], null);
+
+      expect(config('IS_APPLIANCE')).to.equal(true);
+
+      // Put provider back or other tests fail!
+      config.setProvider(key => defaultConfig[key], null);
+    });
+
+    it('should detect non-appliance', () => {
+      const issuerConfig = _.cloneDeep(defaultConfig);
+      issuerConfig.AUTH0_RTA = 'auth0.auth0.com';
+
+      config.setProvider(key => issuerConfig[key], null);
+
+      expect(config('IS_APPLIANCE')).to.equal(false);
+
+      // Put provider back or other tests fail!
+      config.setProvider(key => defaultConfig[key], null);
     });
 
     it('test getValue and setValue', () => {
-      config.setProvider((key) => defaultConfig[key], null);
+      config.setProvider(key => defaultConfig[key], null);
 
-      expect(config.setValue('SOME_KEY', 'something else')).to.not.throw;
+      expect(config.setValue('SOME_KEY', 'something else')).to.not.throw; // eslint-disable-line no-unused-expressions
       expect(config.getValue('SOME_KEY')).to.equal('something else');
     });
 

--- a/webtask.json
+++ b/webtask.json
@@ -40,6 +40,11 @@
       "example": "https://cdn.fabrikam.com/static/extensions/theme/favicon.png",
       "required": false
     },
+    "AUTH0_ISSUER_DOMAIN": {
+      "description": "Custom domain",
+      "example": "https://example.com",
+      "required": false
+    },
     "FEDERATED_LOGOUT": {
       "description": "Also sign out from the IDP when users logout?",
       "type": "select",

--- a/webtask.json
+++ b/webtask.json
@@ -40,7 +40,7 @@
       "example": "https://cdn.fabrikam.com/static/extensions/theme/favicon.png",
       "required": false
     },
-    "AUTH0_ISSUER_DOMAIN": {
+    "AUTH0_CUSTOM_DOMAIN": {
       "description": "Custom domain",
       "example": "https://example.com",
       "required": false


### PR DESCRIPTION
## ✏️ Changes
`AUTH0_ISSUER_DOMAIN` secret has been exposed in the webtask.json. This secret can be used instead of AUTH0_DOMAIN to support custom domains.
  
## 🎯 Testing
✅ This change has been tested in a Webtask (including appliance with custom domain)
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ Can be deployed now.