### PR TITLE
Allow removing unconfirmed MFA enrollments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [3.6.1] - Unreleased
+## [3.6.1] - 2019-04-19
 
 ### Fixed
 - `PUBLIC_WT_URL` generation fixed for specific clusters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [3.6.2] - Unreleased
+
+### Fixed
+- `Remove MFA` for unconfirmed enrollments
+
 ## [3.6.1] - 2019-04-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [3.6.2] - Unreleased
+## [3.6.2] - 2019-04-25
 
 ### Fixed
 - `Remove MFA` for unconfirmed enrollments

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",
   "engines": {
     "node": ">8.9"

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -300,12 +300,16 @@ export default (storage, scriptManager) => {
                 return accessToken;
               }))
           .then((accessToken) => {
-            if (data.user.multifactor && data.user.multifactor.indexOf('guardian') >= 0) {
+            const checkGuardian = !!data.user.multifactor_last_modified
+              || (data.user.multifactor && data.user.multifactor.indexOf('guardian') >= 0);
+            if (checkGuardian) {
               return requestGuardianEnrollments(accessToken, req.params.id)
                 .then((enrollments) => {
-                  if (!enrollments || !enrollments.length) {
+                  if (data.user.multifactor && (!enrollments || !enrollments.length)) {
                     data.user.multifactor = data.user.multifactor.filter(item => item !== 'guardian');
                     data.user.multifactor = data.user.multifactor.length ? data.user.multifactor : null;
+                  } else if (enrollments && !data.user.multifactor) {
+                    data.user.multifactor = [ 'guardian' ];
                   }
 
                   return res.json(data);

--- a/tests/server/routes/users.tests.js
+++ b/tests/server/routes/users.tests.js
@@ -352,6 +352,10 @@ describe('#users router', () => {
 
     it('should return user`s record 3', (done) => {
       nock(domain)
+        .get('/api/v2/users/3/enrollments')
+        .reply(200, []);
+
+      nock(domain)
         .get(/user-blocks\/3/)
         .reply(200, { blocked_for: [ 'yummy' ] });
 
@@ -386,6 +390,28 @@ describe('#users router', () => {
         .expect(400)
         .end((err) => {
           if (err) return done(err);
+          done();
+        });
+    });
+
+    it('should return user with guardian mfa', (done) => {
+      nock(domain)
+        .get(/user-blocks\/3/)
+        .reply(200, { blocked_for: [ ] });
+
+      nock(domain)
+        .get('/api/v2/users/3/enrollments')
+        .reply(200, [ { id: 'pid01' } ]);
+
+      request(app)
+        .get('/users/3')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          expect(res.body.user.email).to.equal('user3@example.com');
+          expect(res.body.user.multifactor).to.be.an('array');
+          expect(res.body.user.multifactor[0]).to.equal('guardian');
           done();
         });
     });

--- a/tests/utils/dummyData.js
+++ b/tests/utils/dummyData.js
@@ -15,7 +15,7 @@ export const defaultLogs = [
 export const defaultUsers = [
   { email: 'user1@example.com', user_id: 1, app_metadata: { department: 'deptA' } },
   { email: 'user2@example.com', user_id: 2, app_metadata: { department: 'deptA' } },
-  { email: 'user3@example.com', user_id: 3, app_metadata: { department: 'deptA' } },
+  { email: 'user3@example.com', user_id: 3, app_metadata: { department: 'deptA' }, multifactor_last_modified: 'just now' },
   { email: 'user4@example.com', user_id: 4, app_metadata: { department: 'deptB' } },
   { email: 'user5@example.com', user_id: 5, app_metadata: { department: 'deptB' } }
 ];

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Delegated Administration Dashboard",
   "name": "auth0-delegated-admin",
-  "version": "3.6.1",
+  "version": "3.6.2",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",


### PR DESCRIPTION
## ✏️ Changes
  DAE does not allow users to remove MFA, if the enrollment wasn't confirmed. Checking all enrollments on user request should fix this issue.
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/projects/ESD/queues/custom/321/ESD-320
  
## 🎯 Testing
✅ This change has been tested in a Webtask
✅ This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  