### PR TITLE
Fixed extra information leak for connections and applications

### DIFF
--- a/server/routes/applications.js
+++ b/server/routes/applications.js
@@ -6,9 +6,10 @@ import multipartRequest from '../lib/multipartRequest';
 export default () => {
   const api = Router();
   api.get('/', (req, res, next) => {
-    multipartRequest(req.auth0, 'clients', { is_global: false, fields: 'client_id,name,callbacks,app_type' })
+    multipartRequest(req.auth0, 'clients', { is_global: false, fields: 'client_id,name,app_type' })
       .then(clients => _.chain(clients)
         .filter(client => client.app_type === 'spa' || client.app_type === 'native' || client.app_type === 'regular_web')
+        .map(({ client_id, name }) => ({ client_id, name }))
         .sortBy(client => client.name.toLowerCase())
         .value()
       )

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -29,6 +29,14 @@ export default (scriptManager) => {
             return result;
           });
       })
+      // need to filter out everything except:
+      //  id, name, options.requires_username
+      .then(connections => connections.map(conn => ({
+        id: conn.id,
+        name: conn.name,
+        strategy: conn.strategy,
+        options: conn.options ? { requires_username: conn.options.requires_username } : null
+      })))
       .then(connections => res.json(connections))
       .catch(next);
   });

--- a/tests/server/routes/applications.tests.js
+++ b/tests/server/routes/applications.tests.js
@@ -1,0 +1,58 @@
+import _ from 'lodash';
+import expect from 'expect';
+import Promise from 'bluebird';
+import request from 'supertest';
+import express from 'express';
+import bodyParser from 'body-parser';
+
+import applications from '../../../server/routes/applications';
+import { defaultApplications } from '../../utils/dummyData';
+
+
+describe('#connections router', () => {
+  const fakeApiClient = (req, res, next) => {
+    req.auth0 = {
+      clients: {
+        getAll: () => Promise.resolve(defaultApplications)
+      }
+    };
+
+    next();
+  };
+
+  const app = express();
+
+  app.use(bodyParser.json());
+  app.use(bodyParser.urlencoded({ extended: false }));
+  app.use('/applications', fakeApiClient, applications());
+
+  describe('#Get Applications', () => {
+    it('should return expected clients', (done) => {
+      request(app)
+        .get('/applications')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) throw err;
+          expect(res.body.length).toEqual(3);
+          done();
+        });
+    });
+
+    it('should return clients only with expected fields', (done) => {
+      request(app)
+        .get('/applications')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) throw err;
+
+          res.body.forEach(client => {
+            expect(Object.keys(client).sort()).toEqual([ 'client_id', 'name' ]);
+          });
+
+          done();
+        });
+    });
+  });
+});

--- a/tests/server/routes/connections.tests.js
+++ b/tests/server/routes/connections.tests.js
@@ -50,7 +50,7 @@ describe('#connections router', () => {
         .expect(200)
         .end((err, res) => {
           if (err) throw err;
-          expect(res.body).toEqual(defaultConnections.slice(0, 2));
+          expect(res.body.length).toEqual(2);
           done();
         });
     });
@@ -78,7 +78,7 @@ describe('#connections router', () => {
         .expect(200)
         .end((err, res) => {
           if (err) throw err;
-          expect(res.body).toEqual(defaultConnections);
+          expect(res.body.length).toEqual(defaultConnections.length);
           done();
         });
     });
@@ -92,7 +92,31 @@ describe('#connections router', () => {
         .expect(200)
         .end((err, res) => {
           if (err) throw err;
-          expect(res.body).toEqual(defaultConnections);
+          expect(res.body.length).toEqual(defaultConnections.length);
+          done();
+        });
+    });
+
+    it('should return connections only with expected fields', (done) => {
+      storage.data = {};
+
+      request(app)
+        .get('/connections')
+        .expect('Content-Type', /json/)
+        .expect(200)
+        .end((err, res) => {
+          if (err) throw err;
+
+          res.body.forEach(client => {
+            expect(Object.keys(client).length).toExist().toBeGreaterThanOrEqualTo(3).toBeLessThanOrEqualTo(4);
+            expect(client).toIncludeKeys([ 'id', 'name', 'strategy' ]);
+
+            const options = client.options;
+            if (options) {
+              expect(Object.keys(options)).toEqual([ 'requires_username' ]);
+            }
+          });
+
           done();
         });
     });

--- a/tests/utils/dummyData.js
+++ b/tests/utils/dummyData.js
@@ -21,9 +21,17 @@ export const defaultUsers = [
 ];
 
 export const defaultConnections = [
-  { name: 'conn-a', strategy: 'auth0' },
-  { name: 'conn-b', strategy: 'auth0' },
-  { name: 'conn-c', strategy: 'auth0' }
+  { id: '1', name: 'conn-a', strategy: 'auth0', options: { requires_username: false } },
+  { id: '2', name: 'conn-b', strategy: 'auth0', options: { requires_username: true, blah_blah: 'dummy' } },
+  { id: '3', name: 'conn-c', strategy: 'auth0', options: { requires_username: false, blah_blah: 'dummy' } },
+  { id: '4', name: 'conn-c', strategy: 'auth0' }
+];
+
+export const defaultApplications = [
+  { client_id: '1', name: 'client-1', app_type: 'spa', someprop: 'dummy' },
+  { client_id: '2', name: 'client-2', app_type: 'regular_web', callbacks: 'https://callback' },
+  { client_id: '3', name: 'client-3', app_type: 'native' },
+  { client_id: '4', name: 'client-4', app_type: 'm2m' }
 ];
 
 export const defaultScripts = {


### PR DESCRIPTION
## ✏️ Changes
  
Some server-side endpoints were returning extra information not used by the extension.
A customer reported that this information is sensitive and must be removed - this PR fixes that.

I changed:
1. `/applications` endpoint to return only `client_id, name`
2. `/connections` endpoint to return only `id, name, strategy, options.requires_username`

Added unit tests to ensure that any extra fields are removed from initial data.

## 🎯 Testing
  
To test this change, ensure that any application and connection-related functionality works correctly. For example:
1. Applications are used during password reset - try to send a password reset email.
2. Connections are used during user creation - try to create a user having several connections with different combinations of settings, especially some requiring username and some - not requiring it.
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
✅ This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
  
No dependencies have been added or removed, there should not be any visible change in functionality.
  
## 🔥 Rollback
  
Rollback may be needed if any of existing functionality breaks due to missing fields in the returned data.
  
### 📄 Procedure
  
No specific rollback procedure - just revert the extension to previous version.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
