### PR TITLE
Fix to remove rendering of reserved fields in custom field edit form

### DIFF
--- a/client/components/Users/UserActions.jsx
+++ b/client/components/Users/UserActions.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { MenuItem, DropdownButton } from 'react-bootstrap';
 import _ from 'lodash';
 import { removeBlockedIPs } from "../../reducers/removeBlockedIPs";
+import { RESERVED_USER_FIELDS } from '../../constants';
 
 export default class UserActions extends Component {
   static propTypes = {
@@ -85,7 +86,7 @@ export default class UserActions extends Component {
     }
 
     /* Only display this if there are editable fields */
-    const fieldsWithEdit = _.filter(this.props.userFields, field => field.edit);
+    const fieldsWithEdit = _.filter(this.props.userFields, field => !_.includes(RESERVED_USER_FIELDS, field.property) && field.edit);
     if (fieldsWithEdit.length <= 0) return null;
 
     return (

--- a/client/components/Users/UserFieldsChangeForm.jsx
+++ b/client/components/Users/UserFieldsChangeForm.jsx
@@ -6,6 +6,8 @@ import { reduxForm } from 'redux-form';
 
 import UserCustomFormFields from './UserCustomFormFields';
 
+import { RESERVED_USER_FIELDS } from '../../constants';
+
 class UserFieldsChangeForm extends Component {
   static propTypes = {
     initialValues: PropTypes.object,
@@ -15,19 +17,17 @@ class UserFieldsChangeForm extends Component {
     submitting: PropTypes.bool,
     customFields: PropTypes.array,
     languageDictionary: PropTypes.object,
-    loading: PropTypes.bool,
+    loading: PropTypes.bool
   };
 
   render() {
-
     const fields = this.props.customFields || [];
 
     if (fields.length === 0) return null;
 
     const languageDictionary = this.props.languageDictionary || {};
 
-    const ignoreFields = [ 'username', 'memberships', 'connection', 'password', 'email', 'repeatPassword' ];
-    const filteredCustomFields = _.filter(fields, field => !_.includes(ignoreFields, field.property) && field.edit);
+    const filteredCustomFields = _.filter(fields, field => !_.includes(RESERVED_USER_FIELDS, field.property) && field.edit);
 
     if (filteredCustomFields.length === 0) return null;
 
@@ -48,7 +48,7 @@ class UserFieldsChangeForm extends Component {
             {languageDictionary.cancelButtonText || 'Cancel'}
           </Button>
           <Button bsSize="large" bsStyle="primary" disabled={loading} onClick={this.props.handleSubmit}>
-           {loading ? languageDictionary.savingText || 'Saving....' : languageDictionary.updateButtonText || 'Update'}
+            {loading ? languageDictionary.savingText || 'Saving....' : languageDictionary.updateButtonText || 'Update'}
           </Button>
         </Modal.Footer>
       </div>

--- a/client/constants.js
+++ b/client/constants.js
@@ -250,3 +250,6 @@ export const FETCH_LANGUAGE_DICTIONARY_FULFILLED = 'FETCH_LANGUAGE_DICTIONARY_FU
 
 // Access level constants
 export const SUPER_ADMIN = 2;
+
+// The list of reserved user fields that must not be rendered in the custom fields edit form
+export const RESERVED_USER_FIELDS = [ 'username', 'memberships', 'connection', 'password', 'email', 'repeatPassword', 'resetPassword' ];

--- a/tests/client/components/Users/UserActions.tests.js
+++ b/tests/client/components/Users/UserActions.tests.js
@@ -142,7 +142,7 @@ describe('#Client-Components-UserActions', () => {
     checkMenuItems(menuItems, targets);
   });
 
-  it.only('should not render reset password, if disabled in userFields', () => {
+  it('should not render reset password, if disabled in userFields', () => {
     const userFields = [
       { property: 'password', edit: false },
       { property: 'resetPassword', edit: true }

--- a/tests/client/components/Users/UserActions.tests.js
+++ b/tests/client/components/Users/UserActions.tests.js
@@ -142,7 +142,7 @@ describe('#Client-Components-UserActions', () => {
     checkMenuItems(menuItems, targets);
   });
 
-  it('should not render reset password, if disabled in userFields', () => {
+  it.only('should not render reset password, if disabled in userFields', () => {
     const userFields = [
       { property: 'password', edit: false },
       { property: 'resetPassword', edit: true }
@@ -153,7 +153,6 @@ describe('#Client-Components-UserActions', () => {
       "Change Email": changeEmail(),
       "Change Username": changeUsername(),
       "Reset Password": resetPassword(),
-      "Change Profile": changeFields(),
       "Delete User": deleteUser(),
       "Resend Verification Email": resendVerificationEmail()
     };

--- a/tests/client/components/Users/UserFieldsChangeForm.tests.js
+++ b/tests/client/components/Users/UserFieldsChangeForm.tests.js
@@ -73,7 +73,12 @@ describe('#Client-Components-UserFieldsChangeForm', () => {
   });
 
   it('should not render if the custom fields dont edit', () => {
-    const provider = renderComponent({}, [{ property: 'do.not.edit.me', edit: false }, { property: 'do.not.edit.me.either' }]);
+    const provider = renderComponent({}, [ { property: 'do.not.edit.me', edit: false }, { property: 'do.not.edit.me.either' } ]);
+    checkForm(provider, false);
+  });
+
+  it('should not render reserved fields', () => {
+    const provider = renderComponent({}, [ { property: 'password' } ]);
     checkForm(provider, false);
   });
 


### PR DESCRIPTION
## ✏️ Changes
  
Customer reported that reserved fields like passwordReset are being rendered in custom fields change form - this must be removed as these fields control the display of user menu actions, but bust not be rendered as custom fields.

In this PR, the "reserved" fields were extracted into external constants and reused in UserActions component to filter out any input custom fields.
  
## 🎯 Testing
  
No new unit tests were added for UserActions - I am not sure how to test it. To test the actual functionality it requires a settings query hook like the following:
```
function(ctx, callback) {
  return callback(null, {
    userFields: [ {
      property: "resetPassword",
      edit: true,
      display: false
    }, {
      property: "password",
      edit: false
    }  ]
  });
}
```

Then the fields in the hook above must not be rendered in Custom Fields edit form in user properties.
   
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment

✅ This can be deployed any time

## 🎡 Rollout

Requires manual testing as per "Testing" section above.

## 🔥 Rollback
  
Rollback as usual, nothing specific.

## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
