### PR TITLE
[DO-NOT-MERGE] IUM-529: Workaround users sort limitation in stats and users pages

### DIFF
--- a/client/reducers/users.js
+++ b/client/reducers/users.js
@@ -13,8 +13,8 @@ const initialState = {
   pages: 1,
   selectedFilter: '',
   searchValue: '',
-  sortProperty: 'last_login',
-  sortOrder: -1
+  sortProperty: 'name',
+  sortOrder: 1
 };
 
 export const users = createReducer(fromJS(initialState), { // eslint-disable-line import/prefer-default-export

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -196,7 +196,7 @@ export default (storage, scriptManager) => {
 
     const sort = req.query.sortProperty && req.query.sortOrder
       ? `${req.query.sortProperty}:${req.query.sortOrder}`
-      : 'last_login:-1';
+      : 'name:1';
 
     scriptManager.execute('filter', filterContext)
       .then((filter) => {

--- a/tests/client/reducers/users.tests.js
+++ b/tests/client/reducers/users.tests.js
@@ -13,8 +13,8 @@ const initialState = {
   pages: 1,
   searchValue: '',
   selectedFilter: '',
-  sortProperty: 'last_login',
-  sortOrder: -1
+  sortProperty: 'name',
+  sortOrder: 1
 };
 
 describe('users reducer', () => {
@@ -107,8 +107,8 @@ describe('users reducer', () => {
         pages: 1,
         searchValue: '',
         selectedFilter: '',
-        sortProperty: 'last_login',
-        sortOrder: -1
+        sortProperty: 'name',
+        sortOrder: 1
       }
     );
   });
@@ -172,8 +172,8 @@ describe('users reducer', () => {
         pages: 1,
         searchValue: '',
         selectedFilter: undefined,
-        sortProperty: 'last_login',
-        sortOrder: -1
+        sortProperty: 'name',
+        sortOrder: 1
       }
     );
   });


### PR DESCRIPTION
## ✏️ Changes
  
* Change the default sortProperty (initial state) to `Name ASC`. The current default `Last Login DESC` has some limitations for customers with primaryOrderBy flag disabled in User Search V3 and it cause UX issues when the list has more than 1000 results.

## 📷 Screenshots
 
![Screen Shot 2019-06-19 at 08 43 20](https://user-images.githubusercontent.com/225529/59762762-57e20980-926e-11e9-8e56-786dd0a4a654.png)
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/IUM-529
  
## 🎯 Testing
   
✅ This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
⚠️ This should not be merged until:
https://github.com/auth0/docs/pull/7745
https://github.com/auth0/manhattan/pull/679
  
## 🎡 Rollout
  
Check if default sort is `Name ASC`.