### PR TITLE
fixed permissions check for psaas with custom domain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.6.4] - Unreleased
+
+### Fixed
+
+- User permissions check for PSaaS with custom domain enabled
+
 ## [3.6.3] - 2019-05-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [3.6.4] - Unreleased
+## [3.6.4] - 2019-07-09
 
 ### Fixed
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",
   "engines": {
     "node": ">8.9"

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -68,7 +68,7 @@ export default (storage) => {
 
   // Allow end users to authenticate.
   api.use(middlewares.authenticateUsers.optional({
-    domain: config('AUTH0_CUSTOM_DOMAIN'),
+    domain: config('IS_APPLIANCE') ? config('AUTH0_DOMAIN') : config('AUTH0_CUSTOM_DOMAIN'),
     audience: config('EXTENSION_CLIENT_ID'),
     credentialsRequired: false,
     onLoginSuccess: (req, res, next) => {

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Delegated Administration Dashboard",
   "name": "auth0-delegated-admin",
-  "version": "3.6.3",
+  "version": "3.6.4",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",


### PR DESCRIPTION
## ✏️ Changes
  The extension fails to authenticate user if custom domain is enabled (PSaaS) because it expects custom domain to be issuer, but in case of PSaaS, the issuer is always original domain. Fixed by checking `IS_APPLIANCE`.
  
## 🔗 References
  Jira: https://auth0team.atlassian.net/projects/ESD/queues/custom/321/ESD-1097
  
## 🎯 Testing
✅ This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
🚫 This change has been tested for performance
  
## 🚀 Deployment
✅ This can be deployed any time
  
## 🖥 Appliance
  These changes only affects appliances
