### PR TITLE
Added flag to allow IdP-Initiated Sign-On to the Dashboard

### DIFF
--- a/client/actions/auth.js
+++ b/client/actions/auth.js
@@ -175,7 +175,7 @@ export function loadCredentials() {
 
       return webAuth.parseHash({
         hash: window.location.hash,
-        __enableIdPInitiatedLogin: window.config.ALLOW_IDP_INITIATED_SIGNON
+        __enableIdPInitiatedLogin: window.config.IDP_INITIATED_SIGNON
       }, (err, hash) => {
         if (err || !hash || !hash.idToken) {
           /* Must have had hash, but didn't get an idToken in the hash */

--- a/client/actions/auth.js
+++ b/client/actions/auth.js
@@ -174,7 +174,8 @@ export function loadCredentials() {
       });
 
       return webAuth.parseHash({
-        hash: window.location.hash
+        hash: window.location.hash,
+        __enableIdPInitiatedLogin: window.config.ALLOW_IDP_INITIATED_SIGNON
       }, (err, hash) => {
         if (err || !hash || !hash.idToken) {
           /* Must have had hash, but didn't get an idToken in the hash */

--- a/package.json
+++ b/package.json
@@ -183,6 +183,21 @@
             "text": "Yes"
           }
         ]
+      },
+      "IDP_INITIATED_SIGNON": {
+        "description": "Allow IdP-Initiated Single Sign-On?",
+        "type": "select",
+        "allowMultiple": false,
+        "options": [
+          {
+            "value": "false",
+            "text": "No"
+          },
+          {
+            "value": "true",
+            "text": "Yes"
+          }
+        ]
       }
     },
     "externals": [

--- a/server/routes/html.js
+++ b/server/routes/html.js
@@ -82,6 +82,7 @@ export default () => {
       BASE_PATH: `${basePath}${locale}/`,
       TITLE: config('TITLE'),
       FEDERATED_LOGOUT: config('FEDERATED_LOGOUT') === 'true',
+      IDP_INITIATED_SIGNON: config('IDP_INITIATED_SIGNON') === 'true',
       AUTH0_MANAGE_URL: config('AUTH0_MANAGE_URL') || 'https://manage.auth0.com',
       LOCALE: locale
     };

--- a/webtask.json
+++ b/webtask.json
@@ -60,8 +60,8 @@
         }
       ]
     },
-    "ALLOW_IDP_INITIATED_SIGNON": {
-      "description": "AlloW IdP-Initiated Single Sign-On?",
+    "IDP_INITIATED_SIGNON": {
+      "description": "Allow IdP-Initiated Single Sign-On?",
       "type": "select",
       "allowMultiple": false,
       "options": [

--- a/webtask.json
+++ b/webtask.json
@@ -59,6 +59,21 @@
           "text": "Yes"
         }
       ]
+    },
+    "ALLOW_IDP_INITIATED_SIGNON": {
+      "description": "AlloW IdP-Initiated Single Sign-On?",
+      "type": "select",
+      "allowMultiple": false,
+      "options": [
+        {
+          "value": "false",
+          "text": "No"
+        },
+        {
+          "value": "true",
+          "text": "Yes"
+        }
+      ]
     }
   }
 }


### PR DESCRIPTION
## ✏️ Changes
  
Added flag to allow IdP-Initiated Sign-On to the dashboard if desired. Per [Auth0 documentation](https://auth0.com/docs/protocols/saml/idp-initiated-sso#risks-of-using-an-idp-initiated-sso-flow) allowing IdP-initiated sign-on is not necessarily risk-free, so adding a flag allows users to manage the risk themselves.
  
## 📷 Screenshots
 
No visual changes (apart from a new field in the extension configuration)
  
## 🔗 References
 
Refer to [IdP-Initiated Single Sign-On](https://auth0.com/docs/protocols/saml/idp-initiated-sso) for details on the auth0.js flag that allows IdP-initiated sign-on.

## 🎯 Testing
  
Functional testing was performed during development. 

Requirements for testing are a connection within Auth0 capable of IdP-initiated signon.

No dependencies were modified as part of this change.
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
 
Users will not be impacted by this change, unless they reconfigure the new flag to TRUE. When the flag is set to TRUE, this will not cause any breaking changes or impacts for users. Existing implicit grant authentication will continue to operate.
  
