### PR TITLE
AUTHZ-1338 - Remove Client option from password reset dialog

### DIFF
--- a/client/actions/user.js
+++ b/client/actions/user.js
@@ -422,13 +422,11 @@ export function cancelPasswordReset() {
 export function resetPassword(application) {
   return (dispatch, getState) => {
     const { user: { user_id }, connection } = getState().passwordReset.toJS();
-    const clientId = application.client.value || application.client;
     dispatch({
       type: constants.PASSWORD_RESET,
       payload: {
         promise: axios.post(`/api/users/${user_id}/password-reset`, {
-          connection,
-          clientId
+          connection
         })
       },
       meta: {

--- a/client/containers/Users/Dialogs/PasswordResetDialog.jsx
+++ b/client/containers/Users/Dialogs/PasswordResetDialog.jsx
@@ -6,11 +6,9 @@ import { Error, Confirm } from 'auth0-extension-ui';
 
 import submitForm from '../../../actions/submitForm';
 import { userActions } from '../../../actions';
-import getAppsForConnection from '../../../selectors/getAppsForConnection';
 import getDialogMessage from './getDialogMessage';
 import { getName, mapValues } from '../../../utils/display';
 import {
-  useClientField,
   useDisabledConnectionField,
   useDisabledEmailField
 } from '../../../utils/useDefaultFields';
@@ -22,7 +20,6 @@ export default connectContainer(class extends Component {
   static stateToProps = (state) => ({
     connections: state.connections,
     passwordReset: state.passwordReset,
-    appsForConnection: getAppsForConnection(state),
     settings: (state.settings.get('record') && state.settings.get('record').toJS().settings) || {},
     languageDictionary: state.languageDictionary
   });
@@ -36,15 +33,12 @@ export default connectContainer(class extends Component {
     cancelPasswordReset: PropTypes.func.isRequired,
     resetPassword: PropTypes.func.isRequired,
     connections: PropTypes.object.isRequired,
-    passwordReset: PropTypes.object.isRequired,
-    appsForConnection: PropTypes.object
+    passwordReset: PropTypes.object.isRequired
   };
 
   shouldComponentUpdate(nextProps) {
     return nextProps.passwordReset !== this.props.passwordReset ||
-      nextProps.languageDictionary !== this.props.languageDictionary ||
-      // nextProps.settings !== this.props.settings ||
-      nextProps.appsForConnection !== this.props.appsForConnection;
+      nextProps.languageDictionary !== this.props.languageDictionary
   }
 
   onConfirm = () => {
@@ -73,11 +67,10 @@ export default connectContainer(class extends Component {
       getName(user, userFields, languageDictionary));
 
     const fields = _.cloneDeep(userFields) || [];
-    useClientField(true, fields, this.props.appsForConnection.toJS());
     useDisabledConnectionField(true, fields, connection, connections.get('records').toJS());
     useDisabledEmailField(true, fields);
 
-    const allowedFields = ['email', 'client', 'connection'];
+    const allowedFields = ['email', 'connection'];
     const filteredFields = _.filter(fields,
       field => _.includes(allowedFields, field.property));
 
@@ -98,7 +91,7 @@ export default connectContainer(class extends Component {
           {message}
         </p>
         <UserFieldsFormInstance
-          initialValues={mapValues(user, allowedFields, filteredFields, 'edit', languageDictionary, { applications: this.props.appsForConnection.toJS() })}
+          initialValues={mapValues(user, allowedFields, filteredFields, 'edit', languageDictionary)}
           isEditForm={true}
           fields={filteredFields}
           languageDictionary={languageDictionary}

--- a/package-lock.json
+++ b/package-lock.json
@@ -7029,7 +7029,8 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7053,13 +7054,15 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7076,19 +7079,22 @@
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7219,7 +7225,8 @@
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7233,6 +7240,7 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7249,6 +7257,7 @@
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7257,13 +7266,15 @@
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.2.4.tgz",
           "integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -7284,6 +7295,7 @@
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7372,7 +7384,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7386,6 +7399,7 @@
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7481,7 +7495,8 @@
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
           "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7523,6 +7538,7 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7544,6 +7560,7 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7592,13 +7609,15 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.2.tgz",
           "integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -11304,6 +11323,7 @@
           "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
           "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
           "dev": true,
+          "optional": true,
           "requires": {
             "kind-of": "^3.0.2",
             "longest": "^1.0.1",
@@ -11673,7 +11693,8 @@
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
           "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
@@ -11769,6 +11790,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -11821,7 +11843,8 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
           "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "lru-cache": {
           "version": "4.1.3",
@@ -12124,7 +12147,8 @@
           "version": "1.6.1",
           "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
           "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "require-directory": {
           "version": "2.1.1",
@@ -19101,7 +19125,8 @@
             "ansi-regex": {
               "version": "2.1.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "aproba": {
               "version": "1.2.0",
@@ -19122,12 +19147,14 @@
             "balanced-match": {
               "version": "1.0.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -19142,17 +19169,20 @@
             "code-point-at": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -19269,7 +19299,8 @@
             "inherits": {
               "version": "2.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -19281,6 +19312,7 @@
               "version": "1.0.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -19295,6 +19327,7 @@
               "version": "3.0.4",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
@@ -19302,12 +19335,14 @@
             "minimist": {
               "version": "0.0.8",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -19326,6 +19361,7 @@
               "version": "0.5.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -19406,7 +19442,8 @@
             "number-is-nan": {
               "version": "1.0.1",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -19418,6 +19455,7 @@
               "version": "1.4.0",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -19503,7 +19541,8 @@
             "safe-buffer": {
               "version": "5.1.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "safer-buffer": {
               "version": "2.1.2",
@@ -19539,6 +19578,7 @@
               "version": "1.0.2",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -19558,6 +19598,7 @@
               "version": "3.0.1",
               "bundled": true,
               "dev": true,
+              "optional": true,
               "requires": {
                 "ansi-regex": "^2.0.0"
               }
@@ -19601,12 +19642,14 @@
             "wrappy": {
               "version": "1.0.2",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             },
             "yallist": {
               "version": "3.0.3",
               "bundled": true,
-              "dev": true
+              "dev": true,
+              "optional": true
             }
           }
         },

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -374,7 +374,7 @@ export default (storage, scriptManager) => {
     });
 
     const user = req.targetUser;
-    const data = { email: user.email, connection: req.body.connection, client_id: req.body.clientId };
+    const data = { email: user.email, connection: req.body.connection };
     return client.requestChangePasswordEmail(data)
       .then(() => res.sendStatus(204))
       .catch(next);

--- a/tests/client/containers/Users/Dialogs/PasswordResetDialog.tests.js
+++ b/tests/client/containers/Users/Dialogs/PasswordResetDialog.tests.js
@@ -90,11 +90,6 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       .textContent).to.equal(emailLabel);
   };
 
-  const checkClientLabel = (component, passwordLabel) => {
-    expect(document.querySelector('label[for=client]')
-      .textContent).to.equal(passwordLabel);
-  };
-
   const checkConfirm = (component, title) => {
     const confirm = component.find(Confirm);
     expect(confirm.length).to.equal(1);
@@ -108,7 +103,6 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       ' user allowing them to choose a new password.');
     checkConnectionLabel(component, 'Connection');
     checkEmailLabel(component, 'Email');
-    checkClientLabel(component, 'Client (required)');
     checkConfirm(component, 'Reset Password?');
   });
 
@@ -119,7 +113,6 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       ' user allowing them to choose a new password.');
     checkConnectionLabel(component);
     checkEmailLabel(component, 'Email');
-    checkClientLabel(component, 'Client (required)');
     checkConfirm(component, 'Reset Password?');
   });
 
@@ -131,7 +124,6 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       ' user allowing them to choose a new password.');
     checkConnectionLabel(component, 'Connection');
     checkEmailLabel(component, 'Email');
-    checkClientLabel(component, 'Client (required)');
     checkConfirm(component, 'Reset Password?');
   });
 
@@ -209,7 +201,6 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
     const component = renderComponent({ username: 'john', settings });
     checkConnectionLabel(component, 'ConnectionLabel');
     checkEmailLabel(component, 'EmailLabel');
-    checkClientLabel(component, 'ClientLabel');
   });
 
   it('should handle null label name in user fields', () => {
@@ -236,6 +227,5 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
     const component = renderComponent({ username: 'john', settings });
     checkConnectionLabel(component, 'Connection');
     checkEmailLabel(component, 'Email');
-    checkClientLabel(component, 'Client');
   });
 });


### PR DESCRIPTION
This removes an unnecessary "Client" option from the password reset dialog. The `client_id` is not required (or even an argument for) the `requestChangePasswordEmail` method in node-auth0:

https://github.com/auth0/node-auth0/blob/v2.13.0/src/auth/index.js#L436