### PR TITLE
ESD-3554 - Add optional client option to password reset dialog

### DIFF
--- a/client/actions/user.js
+++ b/client/actions/user.js
@@ -422,11 +422,13 @@ export function cancelPasswordReset() {
 export function resetPassword(application) {
   return (dispatch, getState) => {
     const { user: { user_id }, connection } = getState().passwordReset.toJS();
+    const clientId = application.client ? (application.client.value || application.client) :  null;
     dispatch({
       type: constants.PASSWORD_RESET,
       payload: {
         promise: axios.post(`/api/users/${user_id}/password-reset`, {
-          connection
+          connection,
+          clientId
         })
       },
       meta: {

--- a/client/utils/useDefaultFields.js
+++ b/client/utils/useDefaultFields.js
@@ -171,7 +171,7 @@ export const useClientField = (isEditField, fields, clients) => {
     [type]: {
       type: 'select',
       component: 'InputCombo',
-      required: true,
+      required: false,
       options: clients.map(option => ({ value: option.client_id, label: option.name}))
     }
   };

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -374,7 +374,7 @@ export default (storage, scriptManager) => {
     });
 
     const user = req.targetUser;
-    const data = { email: user.email, connection: req.body.connection };
+    const data = { email: user.email, connection: req.body.connection, client_id: req.body.clientId };
     return client.requestChangePasswordEmail(data)
       .then(() => res.sendStatus(204))
       .catch(next);

--- a/tests/client/containers/Users/Dialogs/PasswordResetDialog.tests.js
+++ b/tests/client/containers/Users/Dialogs/PasswordResetDialog.tests.js
@@ -90,6 +90,11 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       .textContent).to.equal(emailLabel);
   };
 
+  const checkClientLabel = (component, passwordLabel) => {
+    expect(document.querySelector('label[for=client]')
+      .textContent).to.equal(passwordLabel);
+  };
+
   const checkConfirm = (component, title) => {
     const confirm = component.find(Confirm);
     expect(confirm.length).to.equal(1);
@@ -103,6 +108,7 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       ' user allowing them to choose a new password.');
     checkConnectionLabel(component, 'Connection');
     checkEmailLabel(component, 'Email');
+    checkClientLabel(component, 'Client');
     checkConfirm(component, 'Reset Password?');
   });
 
@@ -113,6 +119,7 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       ' user allowing them to choose a new password.');
     checkConnectionLabel(component);
     checkEmailLabel(component, 'Email');
+    checkClientLabel(component, 'Client');
     checkConfirm(component, 'Reset Password?');
   });
 
@@ -124,6 +131,7 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
       ' user allowing them to choose a new password.');
     checkConnectionLabel(component, 'Connection');
     checkEmailLabel(component, 'Email');
+    checkClientLabel(component, 'Client');
     checkConfirm(component, 'Reset Password?');
   });
 
@@ -201,6 +209,7 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
     const component = renderComponent({ username: 'john', settings });
     checkConnectionLabel(component, 'ConnectionLabel');
     checkEmailLabel(component, 'EmailLabel');
+    checkClientLabel(component, 'ClientLabel');
   });
 
   it('should handle null label name in user fields', () => {
@@ -227,5 +236,6 @@ describe('#Client-Containers-Users-Dialogs-PasswordResetDialog', () => {
     const component = renderComponent({ username: 'john', settings });
     checkConnectionLabel(component, 'Connection');
     checkEmailLabel(component, 'Email');
+    checkClientLabel(component, 'Client');
   });
 });


### PR DESCRIPTION
## ✏️ Changes
  
This PR introduces the client option back to the password reset dialog. It is optional.
  
## 📷 Screenshots

**Before:**
<img width="660" alt="Screen Shot 2020-01-08 at 11 55 55 AM" src="https://user-images.githubusercontent.com/396400/71964028-e4a1e400-320d-11ea-9d9a-500b73d8b874.png">

**After:**
<img width="656" alt="Screen Shot 2020-01-08 at 11 57 31 AM" src="https://user-images.githubusercontent.com/396400/71964141-13b85580-320e-11ea-8680-97f2aff3c72e.png">


PW Reset Request in the logs w/ and wo/ selecting a client:

<img width="885" alt="Screen Shot 2020-01-08 at 11 38 17 AM" src="https://user-images.githubusercontent.com/396400/71963930-b6240900-320d-11ea-9c24-28afdba07881.png">

Two different PW reset emails due to different client chosen:

<img width="316" alt="Screen Shot 2020-01-08 at 11 37 26 AM" src="https://user-images.githubusercontent.com/396400/71964096-000cef00-320e-11ea-900f-5b13fe1b5245.png">

HTTP requests to the extension w/ and wo/ selecting a client on the UI:
<img width="463" alt="Screen Shot 2020-01-08 at 11 36 33 AM" src="https://user-images.githubusercontent.com/396400/71964179-216ddb00-320e-11ea-90df-b89deaf61a24.png">

<img width="658" alt="Screen Shot 2020-01-08 at 11 36 50 AM" src="https://user-images.githubusercontent.com/396400/71964180-22067180-320e-11ea-8612-273687c6e87e.png">

  
## 🔗 References
https://auth0team.atlassian.net/browse/ESD-3554 
https://github.com/auth0-extensions/auth0-delegated-administration-extension/pull/200
  
## 🎯 Testing
  
🚫 This change has been tested in a Webtask

✅ This change has been tested locally
 
✅This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
   
✅This can be deployed any time
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will see the optional client selection on the PW reset modal. We'll not select a client and it'll send a pw reset email. We'll select a client and it'll send a pw reset email.
  
## 🔥 Rollback
  
We will rollback if we start getting 500s.
  
### 📄 Procedure
  
Revert the PR.
 
## 🖥 Appliance
  
✅ It is compatiable.
