### PR TITLE
[AUTHZ-1382] add flag to prevent overriding for legacy psaas custom domains

### DIFF
--- a/client/actions/auth.js
+++ b/client/actions/auth.js
@@ -12,7 +12,7 @@ const webAuthOptions = {
   redirectUri: `${window.config.BASE_URL}/login`
 };
 
-if (window.config.IS_APPLIANCE) {
+if (window.config.IS_APPLIANCE && window.config.LEGACY_CUSTOM_DOMAIN) {
   webAuthOptions.overrides = {
     __tenant: window.config.AUTH0_DOMAIN.split('.')[0],
     __token_issuer: `https://${window.config.AUTH0_DOMAIN}/`


### PR DESCRIPTION
# ⚠️ Draft PR

## ✏️ Changes
PSaaS began working towards feature parity with custom domains. The override flag I'm overriding in this PR is because the override was only required for the custom domain implementation that PSaaS had. I posed them a question to figure out if all the environments have achieved feature parity in respect to custom domains. 

https://auth0team.atlassian.net/servicedesk/customer/portal/55/PESD-182

Note, I wasn't able to reproduce the blank screen locally. I'm guessing it's due to something else - but hopefully I'll be able to repro it when deploying in development mode. 

In the ticket there is a helpful testland tenant set up with the issue - the reproduction there shows a blank page.
     
## 🔗 References
  
https://auth0team.atlassian.net/wiki/spaces/PSDOC/pages/305464399/Custom+Domains+Migration
https://auth0team.atlassian.net/browse/AUTHZ-1382
  
## 🎯 Testing
  
Ping me and zoom me. The set up was pretty cumbersome. You have to set up custom domains + follow the delegated admin extension. What happens is that an error referring to an incorrect id_token issuer pops up.
   
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
TODO: can this be deployed any time?
  
## 🎡 Rollout

TODO: Deploy it in development mode and try to reproduce the issue live  
  
  
### 📄 Procedure

Not too sure about deployment of extesnions
 
## 🖥 Appliance
  
This change fixes delegated admin extension on appliance.