### PR TITLE
[AUTHZ-1382] remove support for psaas legacy custom domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.0.0] - 2020-02-05
 
-- Remove support for legacy custom domains on PSaaS
+- **Breaking Change:** Remove support for legacy custom domains on PSaaS. This change does not introduce breaking changes to cloud customers.
 - Fix extension to work with new custom domains on PSaaS
 
 ## [3.8.0] - 2020-01-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [4.0.0] - 2020-02-05
+
+- Remove support for legacy custom domains on PSaaS
+- Fix extension to work with new custom domains on PSaaS
+
 ## [3.8.0] - 2020-01-23
 
 ### Changes

--- a/client/actions/auth.js
+++ b/client/actions/auth.js
@@ -12,13 +12,6 @@ const webAuthOptions = {
   redirectUri: `${window.config.BASE_URL}/login`
 };
 
-if (window.config.IS_APPLIANCE) {
-  webAuthOptions.overrides = {
-    __tenant: window.config.AUTH0_DOMAIN.split('.')[0],
-    __token_issuer: `https://${window.config.AUTH0_DOMAIN}/`
-  };
-}
-
 const webAuth = new auth0.WebAuth(webAuthOptions); // eslint-disable-line no-undef
 
 export function login(returnUrl, locale) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.8.0",
+  "version": "4.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -16315,7 +16315,7 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/has-flag/-/has-flag-3.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
           "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "https-proxy-agent": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2716,7 +2716,7 @@
     },
     "ansicolors": {
       "version": "0.3.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/ansicolors/-/ansicolors-0.3.2.tgz",
+      "resolved": "https://registry.npmjs.org/ansicolors/-/ansicolors-0.3.2.tgz",
       "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
     },
     "any-promise": {
@@ -2755,7 +2755,7 @@
     },
     "archy": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/archy/-/archy-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/archy/-/archy-1.0.0.tgz",
       "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
     },
     "are-we-there-yet": {
@@ -4481,7 +4481,7 @@
     },
     "clone-deep": {
       "version": "0.3.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/clone-deep/-/clone-deep-0.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-0.3.0.tgz",
       "integrity": "sha1-NIxhrpzb4O3+BT2R/0zFIdeQ7eg=",
       "requires": {
         "for-own": "^1.0.0",
@@ -6728,7 +6728,7 @@
     },
     "express-conditional-middleware": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/express-conditional-middleware/-/express-conditional-middleware-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/express-conditional-middleware/-/express-conditional-middleware-2.0.0.tgz",
       "integrity": "sha1-2q2ezvedMQz4BYobmtgRWGwVczM=",
       "requires": {
         "once": "1.4.0"
@@ -7252,7 +7252,7 @@
     },
     "for-own": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/for-own/-/for-own-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/for-own/-/for-own-1.0.0.tgz",
       "integrity": "sha1-xjMy9BXO3EsE2/5wz4NklMU8tEs=",
       "requires": {
         "for-in": "^1.0.1"
@@ -8721,7 +8721,7 @@
     },
     "immediate": {
       "version": "3.0.6",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/immediate/-/immediate-3.0.6.tgz",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha1-nbHb0Pr43m++D13V5Wu2BigN5ps="
     },
     "immutable": {
@@ -10021,12 +10021,12 @@
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
       "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.assignin": {
       "version": "4.2.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.assignin/-/lodash.assignin-4.2.0.tgz",
       "integrity": "sha1-uo31+4QesKPoBEIysOJjqNxqKKI="
     },
     "lodash.camelcase": {
@@ -10039,7 +10039,7 @@
     },
     "lodash.clone": {
       "version": "4.5.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
       "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.clonedeep": {
@@ -10080,7 +10080,7 @@
     },
     "lodash.flatten": {
       "version": "4.4.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
       "integrity": "sha1-8xwiIlqWMtK7+OSt2+8kCqdlph8="
     },
     "lodash.flattendeep": {
@@ -10097,7 +10097,7 @@
     },
     "lodash.get": {
       "version": "4.4.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/lodash.get/-/lodash.get-4.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
       "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
     },
     "lodash.includes": {
@@ -10673,7 +10673,7 @@
     },
     "mixin-object": {
       "version": "2.0.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/mixin-object/-/mixin-object-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/mixin-object/-/mixin-object-2.0.1.tgz",
       "integrity": "sha1-T7lJRB2rGCVA8f4DW6YOGUel5X4=",
       "requires": {
         "for-in": "^0.1.3",
@@ -10682,7 +10682,7 @@
       "dependencies": {
         "for-in": {
           "version": "0.1.8",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/for-in/-/for-in-0.1.8.tgz",
+          "resolved": "https://registry.npmjs.org/for-in/-/for-in-0.1.8.tgz",
           "integrity": "sha1-2Hc5COMSVhCZUrH9ubP6hn0ndeE="
         }
       }
@@ -16024,7 +16024,7 @@
     },
     "shallow-clone": {
       "version": "0.1.2",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/shallow-clone/-/shallow-clone-0.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/shallow-clone/-/shallow-clone-0.1.2.tgz",
       "integrity": "sha1-WQnodLp3EG1zrEFM/sH/yofZcGA=",
       "requires": {
         "is-extendable": "^0.1.1",
@@ -16035,7 +16035,7 @@
       "dependencies": {
         "kind-of": {
           "version": "2.0.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/kind-of/-/kind-of-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/kind-of/-/kind-of-2.0.1.tgz",
           "integrity": "sha1-AY7HpM5+OobLkUG+UZ0kyPqpgbU=",
           "requires": {
             "is-buffer": "^1.0.2"
@@ -16562,12 +16562,12 @@
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/camelcase/-/camelcase-2.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
           "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
         },
         "cliui": {
           "version": "3.2.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/cliui/-/cliui-3.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "requires": {
             "string-width": "^1.0.1",
@@ -16611,7 +16611,7 @@
         },
         "yargs": {
           "version": "3.32.0",
-          "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/yargs/-/yargs-3.32.0.tgz",
+          "resolved": "http://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
           "requires": {
             "camelcase": "^2.0.1",
@@ -17117,7 +17117,7 @@
     },
     "snyk-tree": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/snyk-tree/-/snyk-tree-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/snyk-tree/-/snyk-tree-1.0.0.tgz",
       "integrity": "sha1-D7cxdtvzLngvGRAClBYESPkRHMg=",
       "requires": {
         "archy": "^1.0.0"
@@ -17125,7 +17125,7 @@
     },
     "snyk-try-require": {
       "version": "1.3.1",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/snyk-try-require/-/snyk-try-require-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/snyk-try-require/-/snyk-try-require-1.3.1.tgz",
       "integrity": "sha1-bgJvkuZK9/zM6h7lPVJIQeQYohI=",
       "requires": {
         "debug": "^3.1.0",
@@ -18054,12 +18054,12 @@
     },
     "temp-dir": {
       "version": "1.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/temp-dir/-/temp-dir-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-1.0.0.tgz",
       "integrity": "sha1-CnwOom06Oa+n4OvqnB/AvE2qAR0="
     },
     "tempfile": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/tempfile/-/tempfile-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/tempfile/-/tempfile-2.0.0.tgz",
       "integrity": "sha1-awRGhWqbERTRhW/8vlCczLCXcmU=",
       "requires": {
         "temp-dir": "^1.0.0",
@@ -18373,7 +18373,7 @@
     },
     "then-fs": {
       "version": "2.0.0",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/then-fs/-/then-fs-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/then-fs/-/then-fs-2.0.0.tgz",
       "integrity": "sha1-cveS3Z0xcFqRrhnr/Piz+WjIHaI=",
       "requires": {
         "promise": ">=3.2 <8"
@@ -21543,7 +21543,7 @@
     },
     "xmlbuilder": {
       "version": "9.0.7",
-      "resolved": "https://a0us.jfrog.io/a0us/api/npm/npm/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "resolved": "http://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     },
     "xmlchars": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "3.8.0",
+  "version": "4.0.0",
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",
   "engines": {
     "node": ">8.9"

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Delegated Administration Dashboard",
   "name": "auth0-delegated-admin",
-  "version": "3.8.0",
+  "version": "4.0.0",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",


### PR DESCRIPTION
## ✏️ Changes

The originating error is caused due to a flag called IS_APPLIANCE which is activated for PSaaS deployments. This flag works around the disparity between the PSaaS legacy custom domains implementation - namely, the token issuer being auth0 rather than the customer's custom domain. Once a PSaaS environment migrates to achieve parity with Auth0's public environment's custom domains implementations, the work around in the extension gets triggered and causes the extension to fail to load, since migrating allows the token issuer to be set correctly.

For more context, you can check the internal proposal doc.
  
## 🔗 References
  
https://auth0team.atlassian.net/wiki/spaces/Bacca/pages/459833612/Removing+IS+APPLIANCE+flag+for+legacy+custom+domains  

## 🎯 Testing
  
This is a front end change, so I tested it locally. Seems to work fine. I also edited the live webtask with what we had in dev, but there is no difference for the webtask itself.
  
## 🎡 Rollout
  
We'll release the new dist first, without upgrading the webtask version. We'll test that release by proxying a different version locally to point to the new version, make sure everything works as expected. We'll edit the secrets on the webtask that it creates and set the IS_APPLIANCE flag on my tenant with a custom domain. If that doesn't break, then this change is verified.
  
## 🔥 Rollback
  
If any support tickets get raised concerning this
  
### 📄 Procedure
  
Downgrade webtask.json, instruct customers to downgrade.
 
## 🖥 Appliance
  
It is, but only for deployments that are not on our legacy custom domain solution. I spoke to Nikos and he let me know that we won't be upgrading customers' DAE extension unless they migrate. 
