### PR TITLE
Add support for client_credentials tokens to access server API

### DIFF
--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -46,7 +46,11 @@ export default (storage) => {
 
     if (!token) console.error('no token found');
 
-    const promise = tools.managementApi.getClient({
+    // if the 'sub' user_id starts with the 'aud' (i.e. the client ID of the app)
+    // then the user being authenticated is a client_credentials exchange and should
+    // not be looked up in the management API
+    // We'll rely on the id_token have the appropriate role or permission claims
+    const promise = user.sub.startsWith(user.aud) ? user : tools.managementApi.getClient({
       domain: config('AUTH0_DOMAIN'),
       clientId: config('AUTH0_CLIENT_ID'),
       clientSecret: config('AUTH0_CLIENT_SECRET')


### PR DESCRIPTION
I cannot appropriately test this because attempting to install it into my Auth0 tenant causes an error saying it is a reserved auth0 official name. I attempted to change the name and still could not get it to work.

I am trying to write a script that sets up the DAD in a new Auth0 tenant. Specifically I want to configure the "scripts".

When I created the Delegated Admin Dashboard client (as stated in the directions) I instead used a "Regular Web App" and enabled the Client Credentials Exchange.  I then added an API with an identifier that matches the client ID of the client I just created and named it "Delegated Admin Dashboard". I add a single scope to it of "all" named "All Permissions". I then add a client grant between the client and the new API for the all scope.  I then add a client credentials hook to add the roles and scopes to the access token.

This then allows me to do a client_credentials exchange using the client_id and client_secret of the delegated admin dashboard and use the associated token to make RESTful calls to the /server endpoints to allow me to configure it.

Unfortunately without the below change, the DAD will attempt to call the Auth0 get users API.

The below change checks that the "sub" (ie user ID) starts with the "aud" (i.e. audience). The audience in this case is the client ID of the application added above and auth0 passes the string "client_id@clients".  With the below change, a client credentials token will not cause the management API to be called and instead use the access_token claims as the user object.  This change has no affect on normal users logging in as the "client_id@client" is an invalid syntax for an auth0 client_id.