### PR TITLE
Expose user search engine

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -186,7 +186,7 @@ export default (storage, scriptManager) => {
       }
     };
 
-    const searchEngine = (config('AUTH0_RTA').replace('https://', '') !== 'auth0.auth0.com') ? 'v2' : 'v3';
+    const searchEngine = config('USER_SEARCH_ENGINE') || 'v3';
     const quoteChar = searchEngine === 'v2' ? '"' : '';
     let searchQuery = req.query.search;
 

--- a/webtask.json
+++ b/webtask.json
@@ -45,6 +45,22 @@
       "example": "example.com",
       "required": false
     },
+    "USER_SEARCH_ENGINE": {
+      "description": "User search engine. Cloud only supports V3",
+      "type": "select",
+      "default": "v3",
+      "allowMultiple": false,
+      "options": [
+        {
+          "value": "v3",
+          "text": "v3"
+        },
+        {
+          "value": "v2",
+          "text": "v2"
+        }
+      ]
+    },
     "FEDERATED_LOGOUT": {
       "description": "Also sign out from the IDP when users logout?",
       "type": "select",


### PR DESCRIPTION
## ✏️ Changes
  
Expose user search engine to allow private versions select the search they are using. By default use search v3
  
## 📷 Screenshots
 
![image](https://user-images.githubusercontent.com/1765468/78306552-0adbd500-751a-11ea-9865-3e5c917ab091.png)

 
## 🎯 Testing
  
✅This change has been tested in a Webtask
🚫 This change has unit test coverage
🚫 This change has integration test coverage
  
  
## 🚀 Deployment
  
✅This can be deployed any time
  
