### PR TITLE
Add scope to read MFA enrolment

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -47,7 +47,7 @@ export default function (cfg, storageProvider) {
     noAccessToken: true,
     urlPrefix: '/admins',
     sessionStorageKey: 'delegated-admin:apiToken',
-    scopes: 'read:clients delete:clients read:connections read:users update:users delete:users create:users read:logs read:device_credentials update:device_credentials delete:device_credentials delete:guardian_enrollments'
+    scopes: 'read:clients delete:clients read:connections read:users update:users delete:users create:users read:logs read:device_credentials update:device_credentials delete:device_credentials delete:guardian_enrollments read:guardian_enrollments read:guardian_factors'
   }));
 
   app.use('/api', api(storage));


### PR DESCRIPTION
## ✏️ Changes
  
Currently the DAE does not show user MFA enrolment information (for e.g. type, phone number, updated time etc.). Adding these scopes will make Auth0 Management API to return those information
  
  ## 🎯 Testing
   
🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
    
✅ This can be deployed any time
  
