### PR TITLE
Update logTypes.js

### DIFF
--- a/client/utils/logTypes.js
+++ b/client/utils/logTypes.js
@@ -520,6 +520,14 @@ export default {
       color: 'green'
     }
   },
+  gd_send_voice: {
+    event: 'Voice OTP Sent',
+    description: 'Voice OTP for MFA sent successfully sent.',
+    icon: {
+      name: '312',
+      color: 'green'
+    }
+  },
   gd_start_auth: {
     event: 'Second factor started',
     description: 'Second factor authentication event started for MFA.',


### PR DESCRIPTION
Adds recognition for gd_send_voice log type.

## ✏️ Changes

Adds `gd_send_voice` to the dictionary of recognized log types.
  
There are likely other missing log types, given the file has not been updated in 3 years. Unrecognized log types are labelled "Unknown Error", which is misleading. The unrecognized log type may or may not be an error.