### PR TITLE
IDS-4707 - Switch from InputCombo to InputText if there are too many connections to list

### DIFF
--- a/client/actions/user.js
+++ b/client/actions/user.js
@@ -80,7 +80,7 @@ export function requestCreateUser(memberships) {
     dispatch({
       type: constants.REQUEST_CREATE_USER,
       payload: {
-        connection: connections && connections.length && connections[0].name,
+        connection: connections && connections.length && connections.length < 20 && connections[0].name || null,
         memberships: memberships && memberships.length === 1 ? [ memberships[0] ] : [ ]
       }
     });

--- a/client/actions/user.js
+++ b/client/actions/user.js
@@ -5,7 +5,6 @@ import * as constants from '../constants';
 import { fetchUserLogs } from './userLog';
 import { fetchUserDevices } from './userDevice';
 import { getAccessLevel } from './auth';
-import { CONNECTIONS_LIST_LIMIT } from "../constants";
 
 const addRequiredTextParam = (url, languageDictionary) => {
   languageDictionary = languageDictionary || {};
@@ -77,10 +76,15 @@ export function createUser(user, languageDictionary) {
 export function requestCreateUser(memberships) {
   return (dispatch, getState) => {
     const connections = getState().connections.get('records').toJS();
+
+    const connection = connections.length === 0
+      ? null
+      : connections && connections.length && connections[0].name
+
     dispatch({
       type: constants.REQUEST_CREATE_USER,
       payload: {
-        connection: connections && connections.length && connections.length < CONNECTIONS_LIST_LIMIT && connections[0].name || null,
+        connection,
         memberships: memberships && memberships.length === 1 ? [ memberships[0] ] : [ ]
       }
     });

--- a/client/actions/user.js
+++ b/client/actions/user.js
@@ -5,7 +5,7 @@ import * as constants from '../constants';
 import { fetchUserLogs } from './userLog';
 import { fetchUserDevices } from './userDevice';
 import { getAccessLevel } from './auth';
-import { removeBlockedIPs } from "../reducers/removeBlockedIPs";
+import { CONNECTIONS_LIST_LIMIT } from "../constants";
 
 const addRequiredTextParam = (url, languageDictionary) => {
   languageDictionary = languageDictionary || {};
@@ -80,7 +80,7 @@ export function requestCreateUser(memberships) {
     dispatch({
       type: constants.REQUEST_CREATE_USER,
       payload: {
-        connection: connections && connections.length && connections.length < 20 && connections[0].name || null,
+        connection: connections && connections.length && connections.length < CONNECTIONS_LIST_LIMIT && connections[0].name || null,
         memberships: memberships && memberships.length === 1 ? [ memberships[0] ] : [ ]
       }
     });

--- a/client/constants.js
+++ b/client/constants.js
@@ -254,4 +254,4 @@ export const SUPER_ADMIN = 2;
 // The list of reserved user fields that must not be rendered in the custom fields edit form
 export const RESERVED_USER_FIELDS = [ 'username', 'memberships', 'connection', 'password', 'email', 'repeatPassword', 'resetPassword' ];
 
-export const CONNECTIONS_LIST_LIMIT = 20;
+export const CONNECTIONS_LIST_LIMIT = 20000;

--- a/client/constants.js
+++ b/client/constants.js
@@ -253,5 +253,3 @@ export const SUPER_ADMIN = 2;
 
 // The list of reserved user fields that must not be rendered in the custom fields edit form
 export const RESERVED_USER_FIELDS = [ 'username', 'memberships', 'connection', 'password', 'email', 'repeatPassword', 'resetPassword' ];
-
-export const CONNECTIONS_LIST_LIMIT = 20000;

--- a/client/constants.js
+++ b/client/constants.js
@@ -253,3 +253,5 @@ export const SUPER_ADMIN = 2;
 
 // The list of reserved user fields that must not be rendered in the custom fields edit form
 export const RESERVED_USER_FIELDS = [ 'username', 'memberships', 'connection', 'password', 'email', 'repeatPassword', 'resetPassword' ];
+
+export const CONNECTIONS_LIST_LIMIT = 20;

--- a/client/containers/Users/Users.jsx
+++ b/client/containers/Users/Users.jsx
@@ -15,6 +15,7 @@ import './Users.styles.css';
 class Users extends Component {
   static propTypes = {
     loading: PropTypes.bool.isRequired,
+    connectionsLoading: PropTypes.bool.isRequired,
     error: PropTypes.string,
     users: PropTypes.array,
     connections: PropTypes.array,
@@ -44,7 +45,9 @@ class Users extends Component {
 
   componentWillMount = () => {
     this.props.fetchUsers();
-    this.props.fetchConnections();
+    if (!this.props.connectionsLoading) {
+      this.props.fetchConnections();
+    }
   };
 
   onPageChange = (page) => {
@@ -77,7 +80,7 @@ class Users extends Component {
       error,
       users,
       total,
-      connections,
+      connectionsLoading,
       accessLevel,
       nextPage,
       pages,
@@ -102,7 +105,7 @@ class Users extends Component {
         <div className="row content-header">
           <div className="col-xs-12 user-table-content">
             <h1>{languageDictionary.usersTitle || 'Users'}</h1>
-            {( role > 0 && showCreateUser) ?
+            {( !connectionsLoading && role > 0 && showCreateUser) ?
               <button id="create-user-button" className="btn btn-success pull-right new" onClick={this.createUser}>
                 <i className="icon-budicon-473"></i>
                 {languageDictionary.createUserButtonText || 'Create User'}
@@ -158,6 +161,7 @@ function mapStateToProps(state) {
     loading: state.users.get('loading'),
     users: state.users.get('records').toJS(),
     connections: state.connections.get('records').toJS(),
+    connectionsLoading: state.connections.get('loading'),
     total: state.users.get('total'),
     nextPage: state.users.get('nextPage'),
     pages: state.users.get('pages'),

--- a/client/containers/Users/Users.jsx
+++ b/client/containers/Users/Users.jsx
@@ -102,7 +102,7 @@ class Users extends Component {
         <div className="row content-header">
           <div className="col-xs-12 user-table-content">
             <h1>{languageDictionary.usersTitle || 'Users'}</h1>
-            {(connections.length && role > 0 && showCreateUser) ?
+            {( role > 0 && showCreateUser) ?
               <button id="create-user-button" className="btn btn-success pull-right new" onClick={this.createUser}>
                 <i className="icon-budicon-473"></i>
                 {languageDictionary.createUserButtonText || 'Create User'}

--- a/client/utils/useDefaultFields.js
+++ b/client/utils/useDefaultFields.js
@@ -1,5 +1,7 @@
 import _ from 'lodash';
 
+const CONNECTIONS_LIST_LIMIT = 20;
+
 const applyDefaults = (type, fields, property, defaults) => {
   const field = _.find(fields, { property });
 
@@ -61,14 +63,15 @@ export const useConnectionsField = (isEditField, fields, connections, onConnecti
     return _.remove(fields, { property: 'connection' });
   }
 
+  const isConnectionListingLimitExceeded =  connections.length >= CONNECTIONS_LIST_LIMIT;
   const defaults = {
     property: 'connection',
     label: 'Connection',
     [type]: {
       required: true,
-      type: 'select',
-      component: 'InputCombo',
-      options: connections.map(conn => ({ value: conn.name, label: conn.name })),
+      type: 'text',
+      component: isConnectionListingLimitExceeded ? 'InputText' :'InputCombo',
+      options: isConnectionListingLimitExceeded ? undefined : connections.map(conn => ({ value: conn.name, label: conn.name })),
       onChange: onConnectionChange
     }
   };

--- a/client/utils/useDefaultFields.js
+++ b/client/utils/useDefaultFields.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 
-const CONNECTIONS_LIST_LIMIT = 20;
+import { CONNECTIONS_LIST_LIMIT } from "../constants";
 
 const applyDefaults = (type, fields, property, defaults) => {
   const field = _.find(fields, { property });
@@ -63,14 +63,14 @@ export const useConnectionsField = (isEditField, fields, connections, onConnecti
     return _.remove(fields, { property: 'connection' });
   }
 
-  const isConnectionListingLimitExceeded =  connections.length >= CONNECTIONS_LIST_LIMIT;
+  const isConnectionListingLimitExceeded = connections.length >= CONNECTIONS_LIST_LIMIT;
   const defaults = {
     property: 'connection',
-    label: 'Connection',
+    label: isConnectionListingLimitExceeded ? 'Connection Name' : 'Connection',
     [type]: {
       required: true,
-      type: 'text',
-      component: isConnectionListingLimitExceeded ? 'InputText' :'InputCombo',
+      type: isConnectionListingLimitExceeded ? 'text' : 'select',
+      component: isConnectionListingLimitExceeded ? 'InputText' : 'InputCombo',
       options: isConnectionListingLimitExceeded ? undefined : connections.map(conn => ({ value: conn.name, label: conn.name })),
       onChange: onConnectionChange
     }

--- a/package.json
+++ b/package.json
@@ -14,15 +14,13 @@
     "deploy": "a0-ext deploy --package ./dist/package.zip --url http://0.0.0.0:3000/api/extensions",
     "client:build": "a0-ext build:client ./client/app.jsx ./dist/client",
     "extension:build": "a0-ext build:server ./webtask.js ./dist && cp ./dist/auth0-delegated-admin.extension.$npm_package_version.js ./build/bundle.js && cp ./webtask.json ./dist/webtask.json",
-    "serve:dev": "cross-env NODE_ENV=development nodemon -e js --ignore assets/app/ --ignore build/webpack/ --ignore client/ --ignore server/data.json --ignore node_modules/ ./build/webpack/server.js",
+    "serve:dev": "cross-env NODE_ENV=development NODE_OPTIONS=--openssl-legacy-provider nodemon -e js --ignore assets/app/ --ignore build/webpack/ --ignore client/ --ignore server/data.json --ignore node_modules/ ./build/webpack/server.js",
     "serve:prod": "cross-env NODE_ENV=production node index.js",
     "test": "cross-env NODE_ENV=test nyc --reporter=lcov mocha --require ignore-styles tests/mocha.js './tests/**/*.tests.js'",
     "test:watch": "cross-env NODE_ENV=test mocha --require ignore-styles tests/mocha.js './tests/**/*.tests.js' --watch",
     "test:pre": "npm run test:clean && npm run lint:js",
     "test:clean": "rimraf ./coverage && rimraf ./.nyc_output",
-    "extension:size": "cross-env NODE_ENV=production webpack -p --config ./build/extension/webpack.config.js --json > ./build/extension/bundle-size.json && node ./build/extension/bundle-size.js",
-    "snyk-protect": "snyk protect",
-    "prepare": "npm run snyk-protect"
+    "extension:size": "cross-env NODE_ENV=production webpack -p --config ./build/extension/webpack.config.js --json > ./build/extension/bundle-size.json && node ./build/extension/bundle-size.js"
   },
   "keywords": [
     "auth0",

--- a/server/lib/multipartRequest.js
+++ b/server/lib/multipartRequest.js
@@ -21,6 +21,8 @@ export default function(client, entity, opts = {}, fetchOptions = {} ) {
   let total = 0;
   let pageCount = 0;
 
+  console.log({options})
+
   const getTotals = () =>
     getter({ ...options, include_totals: true, page: 0 })
       .then((response) => {

--- a/server/lib/multipartRequest.js
+++ b/server/lib/multipartRequest.js
@@ -21,8 +21,6 @@ export default function(client, entity, opts = {}, fetchOptions = {} ) {
   let total = 0;
   let pageCount = 0;
 
-  console.log({options})
-
   const getTotals = () =>
     getter({ ...options, include_totals: true, page: 0 })
       .then((response) => {

--- a/server/lib/multipartRequest.js
+++ b/server/lib/multipartRequest.js
@@ -1,8 +1,6 @@
 import Promise from 'bluebird';
 import { ArgumentError } from 'auth0-extension-tools';
 
-export const tooManyRecords = Symbol("Record count exceeds limit");
-
 export default function(client, entity, opts = {}, fetchOptions = {} ) {
   const perPage = fetchOptions.perPage || 50;
   const concurrency = fetchOptions.concurrency || 5;
@@ -18,11 +16,7 @@ export default function(client, entity, opts = {}, fetchOptions = {} ) {
 
   const getter = client[entity].getAll;
   const options = { ...opts, per_page: perPage };
-  const result = {
-    success: true,
-    status: "fetched records",
-    data: []
-  };
+  const result = [];
 
   let total = 0;
   let pageCount = 0;
@@ -41,14 +35,14 @@ export default function(client, entity, opts = {}, fetchOptions = {} ) {
         }
 
         const data = response[entity] || response || [];
-        data.forEach(item => result.data.push(item));
+        data.forEach(item => result.push(item));
         return null;
       });
 
   const getPage = (page) =>
     getter({ ...options, page })
       .then((data) => {
-        data.forEach(item => result.data.push(item));
+        data.forEach(item => result.push(item));
         return null;
       });
 
@@ -59,12 +53,10 @@ export default function(client, entity, opts = {}, fetchOptions = {} ) {
         //   - don't return any to the frontend
         //   - will use a free text box in the user creation dialogue
         if (limit && (total > limit)) { 
-          result.success = false;
-          result.status = tooManyRecords;
           return result;
         }
 
-        if (total === 0 || result.data.length >= total) {
+        if (total === 0 || result.length >= total) {
           return result;
         }
 

--- a/server/lib/multipartRequest.js
+++ b/server/lib/multipartRequest.js
@@ -1,7 +1,12 @@
 import Promise from 'bluebird';
 import { ArgumentError } from 'auth0-extension-tools';
 
-export default function(client, entity, opts = {}, perPage = 50, concurrency = 5) {
+
+export default function(client, entity, opts = {}, fetchOptions = {} ) {
+  const perPage = fetchOptions.perPage || 50;
+  const concurrency = fetchOptions.concurrency || 5;
+  const limit = fetchOptions.limit || null;
+
   if (client === null || client === undefined) {
     throw new ArgumentError('Must provide a auth0 client object.');
   }
@@ -20,6 +25,9 @@ export default function(client, entity, opts = {}, perPage = 50, concurrency = 5
     getter({ ...options, include_totals: true, page: 0 })
       .then((response) => {
         total = response.total || 0;
+        if (limit) {
+          total = Math.min(total, limit);
+        }
         pageCount = Math.ceil(total / perPage);
         const data = response[entity] || response || [];
         data.forEach(item => result.push(item));

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -2,12 +2,13 @@ import _ from 'lodash';
 import { Router } from 'express';
 
 import multipartRequest from '../lib/multipartRequest';
-import { CONNECTIONS_LIST_LIMIT } from "../constants";
+// only fetch one page of connections
+const CONNECTIONS_FETCH_LIMIT = 50;
 
 export default (scriptManager) => {
   const api = Router();
   api.get('/', (req, res, next) => {
-    multipartRequest(req.auth0, 'connections', { strategy: 'auth0', fields: 'id,name,strategy,options' }, { perPage: 100, limit: CONNECTIONS_LIST_LIMIT})
+    multipartRequest(req.auth0, 'connections', { strategy: 'auth0', fields: 'id,name,strategy,options' }, { perPage: 100, limit: CONNECTIONS_FETCH_LIMIT})
       .then((connections) => {
         global.connections = connections.map(conn => ({ name: conn.name, id: conn.id }));
         const settingsContext = {

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -3,9 +3,10 @@ import { Router } from 'express';
 
 import multipartRequest from '../lib/multipartRequest';
 
-// the limit on the frontend is 20000 so we need to fetch at least as many connections as that to 
-// check if that limit is reached. If we fetch less than the frontend limit, it would always show the
-// drop down select box which would be broken for tenants with more connections than the limit. 
+// This is the number of connections in a tenant which the DAE can reasonably handle. More than this and it fails to
+// finish loading connections and the "create user" button is never shown. If there are more connections than this
+// in the tenant, we will return zero connections to the front end, and it will use a free text box for connection name
+// in the create user dialogue. 
 const CONNECTIONS_FETCH_LIMIT = 20000;
 
 export default (scriptManager) => {

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -6,8 +6,8 @@ import multipartRequest from '../lib/multipartRequest';
 // This is the number of connections in a tenant which the DAE can reasonably handle. More than this and it fails to
 // finish loading connections and the "create user" button is never shown. If there are more connections than this
 // in the tenant, we will return zero connections to the front end, and it will use a free text box for connection name
-// in the create user dialogue. 
-const CONNECTIONS_FETCH_LIMIT = 200;
+// in the create user dialogue.
+const CONNECTIONS_FETCH_LIMIT = 20000;
 
 export default (scriptManager) => {
   const api = Router();
@@ -16,7 +16,7 @@ export default (scriptManager) => {
       req.auth0,
       'connections',
       { strategy: 'auth0', fields: 'id,name,strategy,options' },
-      { limit: CONNECTIONS_FETCH_LIMIT, perPage: 20 }
+      { limit: CONNECTIONS_FETCH_LIMIT, perPage: 100 }
     )
       .then((connections) => {
         global.connections = connections.map(conn => ({ name: conn.name, id: conn.id }));

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -1,14 +1,13 @@
 import _ from 'lodash';
 import { Router } from 'express';
 
-import { tooManyRecords } from '../lib/multipartRequest';
-
 import multipartRequest from '../lib/multipartRequest';
 
 // the limit on the frontend is 20000 so we need to fetch at least as many connections as that to 
 // check if that limit is reached. If we fetch less than the frontend limit, it would always show the
 // drop down select box which would be broken for tenants with more connections than the limit. 
-const CONNECTIONS_FETCH_LIMIT = 20000;
+// const CONNECTIONS_FETCH_LIMIT = 20000;
+const CONNECTIONS_FETCH_LIMIT = 20;
 
 export default (scriptManager) => {
   const api = Router();
@@ -20,13 +19,7 @@ export default (scriptManager) => {
       { limit: CONNECTIONS_FETCH_LIMIT, perPage: 100 }
     )
       .then((connections) => {
-
-        if (!connections.success && connections.status === tooManyRecords) { 
-          console.log("got back 'too many records'");
-          global.isConnectionsLimitExceeded = true;
-        }
-        
-        global.connections = connections.data.map(conn => ({ name: conn.name, id: conn.id }));
+        global.connections = connections.map(conn => ({ name: conn.name, id: conn.id }));
         const settingsContext = {
           request: {
             user: req.user
@@ -36,7 +29,7 @@ export default (scriptManager) => {
 
         return scriptManager.execute('settings', settingsContext)
           .then((settings) => {
-            let result = _.chain(connections.data)
+            let result = _.chain(connections)
               .sortBy(conn => conn.name.toLowerCase())
               .value();
 

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -6,8 +6,7 @@ import multipartRequest from '../lib/multipartRequest';
 // the limit on the frontend is 20000 so we need to fetch at least as many connections as that to 
 // check if that limit is reached. If we fetch less than the frontend limit, it would always show the
 // drop down select box which would be broken for tenants with more connections than the limit. 
-// const CONNECTIONS_FETCH_LIMIT = 20000;
-const CONNECTIONS_FETCH_LIMIT = 20;
+const CONNECTIONS_FETCH_LIMIT = 20000;
 
 export default (scriptManager) => {
   const api = Router();

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -7,7 +7,7 @@ import multipartRequest from '../lib/multipartRequest';
 // finish loading connections and the "create user" button is never shown. If there are more connections than this
 // in the tenant, we will return zero connections to the front end, and it will use a free text box for connection name
 // in the create user dialogue. 
-const CONNECTIONS_FETCH_LIMIT = 20000;
+const CONNECTIONS_FETCH_LIMIT = 200;
 
 export default (scriptManager) => {
   const api = Router();
@@ -16,7 +16,7 @@ export default (scriptManager) => {
       req.auth0,
       'connections',
       { strategy: 'auth0', fields: 'id,name,strategy,options' },
-      { limit: CONNECTIONS_FETCH_LIMIT, perPage: 100 }
+      { limit: CONNECTIONS_FETCH_LIMIT, perPage: 20 }
     )
       .then((connections) => {
         global.connections = connections.map(conn => ({ name: conn.name, id: conn.id }));

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -8,7 +8,7 @@ const CONNECTIONS_FETCH_LIMIT = 50;
 export default (scriptManager) => {
   const api = Router();
   api.get('/', (req, res, next) => {
-    multipartRequest(req.auth0, 'connections', { strategy: 'auth0', fields: 'id,name,strategy,options' }, { perPage: 100, limit: CONNECTIONS_FETCH_LIMIT})
+    multipartRequest(req.auth0, 'connections', { strategy: 'auth0', fields: 'id,name,strategy,options' }, { limit: CONNECTIONS_FETCH_LIMIT})
       .then((connections) => {
         global.connections = connections.map(conn => ({ name: conn.name, id: conn.id }));
         const settingsContext = {

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -3,10 +3,12 @@ import { Router } from 'express';
 
 import multipartRequest from '../lib/multipartRequest';
 
+const CONNECTIONS_LIST_LIMIT = 50;
+
 export default (scriptManager) => {
   const api = Router();
   api.get('/', (req, res, next) => {
-    multipartRequest(req.auth0, 'connections', { strategy: 'auth0', fields: 'id,name,strategy,options' })
+    multipartRequest(req.auth0, 'connections', { strategy: 'auth0', fields: 'id,name,strategy,options' }, { perPage: 100, limit: CONNECTIONS_LIST_LIMIT})
       .then((connections) => {
         global.connections = connections.map(conn => ({ name: conn.name, id: conn.id }));
         const settingsContext = {

--- a/server/routes/connections.js
+++ b/server/routes/connections.js
@@ -2,8 +2,7 @@ import _ from 'lodash';
 import { Router } from 'express';
 
 import multipartRequest from '../lib/multipartRequest';
-
-const CONNECTIONS_LIST_LIMIT = 50;
+import { CONNECTIONS_LIST_LIMIT } from "../constants";
 
 export default (scriptManager) => {
   const api = Router();

--- a/tests/client/components/Users/UserForm.tests.js
+++ b/tests/client/components/Users/UserForm.tests.js
@@ -249,7 +249,7 @@ describe('#Client-Components-UserForm', () => {
       someOtherKey: 'Some other value'
     };
 
-    const Component = renderComponent(languageDictionary);
+    const Component = renderComponent(everythingOptions, languageDictionary);
 
     expect(Component.length).to.be.greaterThan(0);
     expect(Component.find(Button).filterWhere(element => element.text() === 'Cancel').length).to.equal(1);

--- a/tests/client/utils/useDefaultFields.tests.js
+++ b/tests/client/utils/useDefaultFields.tests.js
@@ -247,13 +247,24 @@ describe('Client-Utils-useDefaultFields', () => {
 
     it('empty array population skip', () => {
       const fields = [];
-      const target = [];
+      const target1 = [{
+        property: 'connection',
+        label: 'Connection Name',
+        edit: {
+          required: true,
+          type: 'text',
+          component: 'InputText',
+          options: undefined,
+          onChange: undefined
+        }
+      }];
+      const target2 = [];
 
       useDefaultFields.useConnectionsField(true, fields, []);
-      expect(fields).to.deep.equal(target);
+      expect(fields).to.deep.equal(target1);
 
       useDefaultFields.useConnectionsField(true, fields, connection);
-      expect(fields).to.deep.equal(target);
+      expect(fields).to.deep.equal(target2);
     });
 
     it('pre populated array', () => {

--- a/tests/client/utils/useDefaultFields.tests.js
+++ b/tests/client/utils/useDefaultFields.tests.js
@@ -321,7 +321,7 @@ describe('Client-Utils-useDefaultFields', () => {
       }];
       const target = [];
 
-      useDefaultFields.useConnectionsField(true, fields, []);
+      useDefaultFields.useConnectionsField(true, fields, connection);
       expect(fields).to.deep.equal(target);
     });
 


### PR DESCRIPTION
## ✏️ Changes
  
With this PR user creation modal box switches between a select and an input based on how many connections are there in a tenant. If too much, instead of listing them all we switch to a text field in which you can type the connection name.
  
## 📷 Screenshots

When < threshold:

<img width="662" alt="image" src="https://github.com/auth0-extensions/auth0-delegated-administration-extension/assets/396400/857f3a36-63a6-405b-b003-4b579adc0047">
 
When > threshold:

<img width="679" alt="image" src="https://github.com/auth0-extensions/auth0-delegated-administration-extension/assets/396400/85dc2c79-e30a-409e-ab8f-73f7775dade4">

  
## 🔗 References
  
https://auth0team.atlassian.net/browse/IDS-4707
  
## 🎯 Testing

Reduce `CONNECTIONS_FETCH_LIMIT` to something low to be able to test it. Run DAE locally, setting up against the deployment of your choice. 

See once the CONNECTIONS_FETCH_LIMIT is exceeded:

1. A textbox to provide connection name.
2. Optional user name area.

See once the CONNECTIONS_FETCH_LIMIT is not exceeded:
1. A select-box listing connection names to choose from.
2. Mandatory user name area only if connection requires a username.

Additionally see:
1. Only a single GET connection call is done from frontend.
    
🚫 This change has been tested in a Webtask
 
✅ This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
Will be released as a new minor version.
  
## 🎡 Rollout
   
In order to verify that the deployment was successful we will try this against a tenant of ours after upgrading DAE to the latest version.
  
## 🔥 Rollback
  
We will rollback given the new DAE version is defective.
  
### 📄 Procedure
  
We'll advertise the old version as the latest version in the extensions list.