### PR TITLE
Remove deploy step from CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,35 +71,8 @@ jobs:
           root: *workspace_root
           paths: .
 
-  deploy:
-    <<: *defaults
-    steps:
-      - attach_workspace:
-          at: *workspace_root
-
-      - run:
-          name: Deploy
-          command: |
-            a0-ext deploy --url https://auth0-extensions-api.herokuapp.com/api/extensions --apiKey ${DEPLOY_TOKEN}
-
 workflows:
   version: 2
   build_and_test:
     jobs:
       - build_and_test
-  build_test_and_deploy:
-    jobs:
-      - build_and_test:
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              only: master
-      - deploy:
-          requires:
-            - build_and_test
-          filters:
-            branches:
-              ignore: /.*/
-            tags:
-              only: /^v.*/


### PR DESCRIPTION
## ✏️ Changes

- The deploy step in the CI doesn't work, because it replies on a heroku app which is no longer functional. This PR removes the deploy step from the Circle CI config.
  
## 🔗 References
  
- part of tidy up from https://auth0team.atlassian.net/browse/IDS-4707
  
## 🎯 Testing

✅ This PR can be tested by observing if the `build_and_test` CI workflow still works
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
## 🎡 Rollout
    
In order to verify that the deployment was successful we will check the CI on this PR
  
## 🔥 Rollback
    
We won't roll back because what was removed was already broken
 