### PR TITLE
fix: [IDS-5332] Change log level back to 'debug'

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "auth0-delegated-admin",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",
   "engines": {
     "node": ">8.9"

--- a/server/lib/logger.js
+++ b/server/lib/logger.js
@@ -4,8 +4,7 @@ const logger = winston.createLogger({
   levels: winston.config.syslog.levels,
   transports: [
     new winston.transports.Console({
-      // max log level handled by this transport - is the max level
-      level: winston.config.syslog.levels.emerg,
+      level: 'debug',
       handleExceptions: true,
       format: winston.format.combine(
           winston.format.timestamp(),

--- a/webtask.json
+++ b/webtask.json
@@ -1,7 +1,7 @@
 {
   "title": "Delegated Administration Dashboard",
   "name": "auth0-delegated-admin",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "author": "auth0",
   "useHashName": false,
   "description": "This extension allows non-dashboard administrators to manage (a subset of) users.",


### PR DESCRIPTION
## ✏️ Changes
  
- Changed winston log level back to 'debug'
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/IDS-5332
  
## 🎯 Testing
  
Tested in a dev space and checked in the realtime webtask log extension that the debug logs are being shown again
![image](https://github.com/user-attachments/assets/c9adca18-ca62-4805-b5b4-24443514fa27)
   
✅ This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
 
  
✅ This can be deployed any time
 
  
## 🎡 Rollout
  
In order to verify that the deployment was successful we will check the extension logs in production.
  
## 🔥 Rollback
  
We will rollback if there's any issues with the extension
  
### 📄 Procedure
  
Revert commit and upload a new patch version of the extension.
