### PR TITLE
feat: [IDS-5562] Increase timeout for /me request in frontend

### DIFF
--- a/client/actions/auth.js
+++ b/client/actions/auth.js
@@ -204,7 +204,7 @@ export function getAccessLevel(onSuccess) {
     payload: {
       promise: axios.get('/api/me', {
         responseType: 'json',
-        timeout: 5000,
+        timeout: 8000,
         headers: { 'Content-Type': 'application/json' }
       })
     }


### PR DESCRIPTION
## ✏️ Changes
  
- Increased the timeout for the request to `/me` from 5s to 8s

Some users with the admin role don't see the admin actions (like the "Configuration" tab on first load because this request was timing out.
  
## 🔗 References
  
https://auth0team.atlassian.net/browse/IDS-5562
  
## 🎯 Testing

Just a number change, no actual functional changes.
Will be tested together with the node 22 update before releasing the new extension version.

🚫 This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
> or
> ⚠️ This should not be merged until:
> - Other PR is merged because REASON
> - After date because REASON
> - Other condition: REASON
  
## 🎡 Rollout
  
> Explain how the change will be verified once released. Manual testing? Functional testing?
  
In order to verify that the deployment was successful we will test this in production
  
## 🔥 Rollback
  
> Explain when and why we will rollback the change.
  
We will rollback if there are any issues with the extension.
  
### 📄 Procedure
  
This commit can be reverted.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
