### PR TITLE
fix: bundle upload script

### DIFF
--- a/tools/cdn.sh
+++ b/tools/cdn.sh
@@ -27,19 +27,21 @@ upload_to_s3() {
 }
 
 upload_bundle() {
-  local bundle="$EXTENSION_NAME.extension.$CURRENT_VERSION.js"
-  local bundle_local_path="dist/$bundle"
-  local bundle_s3_path="$S3_PATH/$bundle"
+  local local_bundle="$EXTENSION_NAME.extension.$CURRENT_VERSION.js"
+  local bundle_local_path="dist/$local_bundle"
+
+  local remote_bundle="$EXTENSION_NAME-$CURRENT_VERSION.js"
+  local bundle_s3_path="$S3_PATH/$remote_bundle"
 
   if [[ ! -f "$bundle_local_path" ]]; then
-      echo "Error: Missing asset - $bundle"
+      echo "Error: Missing asset - $bundle_local_path"
       exit 1
   fi
 
-  if ! file_exists_in_s3 "$S3_PATH" "$bundle"; then
+  if ! file_exists_in_s3 "$S3_PATH" "$remote_bundle"; then
     upload_to_s3 "$bundle_local_path" "$bundle_s3_path" ""
   else
-    echo "There is already a $bundle in the cdn. Bundle upload skipped..."
+    echo "There is already a $remote_bundle in the cdn. Bundle upload skipped..."
   fi
 }
 


### PR DESCRIPTION
## ✏️ Changes

Fix bundle upload script. The bundle should be named `auth0-delegated-admin-<VERSION>.js` instead of `auth0-delegated-admin.extension.<VERSION>.js`
  
  
## 🔗 References

https://auth0team.atlassian.net/browse/IDS-5630
  
## 🎯 Testing

Tested manually using my own s3 bucket.   
   
🚫 This change has been tested in a Webtask

🚫 This change has unit test coverage
 
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
> Can this change be merged at any time? What will the deployment of the change look like? Does this need to be released in lockstep with something else?
  
✅ This can be deployed any time
  
  
## 🎡 Rollout
   
In order to verify that the deployment was successful we will back-up s3 assets and run this script.
  
## 🔥 Rollback
  
> Explain when and why we will rollback the change.

If script does not work properly - we will remove incorrect files from s3 or restore assets from backup.
  
### 📄 Procedure
  
> Explain how the rollback for this change will look like, how we can recover fast.
 
## 🖥 Appliance
  
**Note to reviewers:** ensure that this change is compatible with the Appliance.
