### PR TITLE
fix dependency hash for auth0-extenion-tools

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4456,7 +4456,7 @@
     "node_modules/auth0-extension-tools": {
       "version": "1.5.2",
       "resolved": "https://a0us.jfrog.io/artifactory/api/npm/npm/auth0-extension-tools/-/auth0-extension-tools-1.5.2.tgz",
-      "integrity": "sha512-x2+lU4xwgn5d0Cf0eten1LGgGHjJtewtCv9397Ye6eeJ8pvqWWrmGCnm7AUyuvFQnu56df0tUVdl+lnwiXYMjg==",
+      "integrity": "sha512-hR7YZFJcli4b+QSXhsMkfc5tHh2+pqc5k3MCxxDmLydcrMUhsDx553aJGwtfcqp143RvDLDZYgbMAID9qbocfA==",
       "license": "MIT",
       "dependencies": {
         "async": "2.1.2",


### PR DESCRIPTION
## ✏️ Changes
  
It looks like the binary for `auth0-extension-tools@1.5.2` has changed and so the integrity hash is no longer valid. This replaces the hash with the valid one. 

During investigation we have learned that `auth0-extension-tools@1.5.2` should be replaced with `@0/auth0-extension-tools@1.2.1` but this requires either updating or vendoring in `auth0-extenion-express-tools` which currently still depends on `auth0-extension-tools@1.5.2` and would need to be migrated. There is a prepared branch for this but this should be refined first before we move forward. In this meantime this PR should unblock. 
  
## 📷 Screenshots
 
If there were visual changes to the application with this change, please include before and after screenshots here. If it has animation, please use screen capture software like  to make a gif.
  
## 🔗 References
  
[Jira](https://auth0team.atlassian.net/browse/IDS-7534?atlOrigin=eyJpIjoiNjU0ZDlkMDU4Njk5NDBlZGE5OTdiY2M0MWU0MjJiMzQiLCJwIjoiaiJ9)
  
## 🎯 Testing
  
- build and run and use normally
   
✅ This change has been tested in a Webtask
 
🚫 This change has unit test coverage
  
🚫 This change has integration test coverage
  
🚫 This change has been tested for performance
  
## 🚀 Deployment
  
✅ This can be deployed any time
  
  
## 🎡 Rollout
  
> Explain how the change will be verified once released. Manual testing? Functional testing?
  
In order to verify that the deployment was successful we will …
  
## 🔥 Rollback
  
Can be rolled back anytime
  
  